### PR TITLE
Fix tests broken due to inactive features/conditional compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,11 @@ colored = "2.2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[[example]]
+name = "cct"
+required-features = ["cct"]
+
+[[example]]
+name = "cri"
+required-features = ["cri"]

--- a/README.md
+++ b/README.md
@@ -106,14 +106,18 @@ Another source of light are electric lamps, such as incandescent light bulbs.
 They generate light by thermal emission from a very hot tungsten filament in a glass envelope.
 In physics, the spectral properties of thermal emission is described by Planck's law.
 For incandescent light bulbs, the CIE recommends using the A-illuminant, in this library available as [`StdIlluminant::A`](crate::std_illuminants::StdIlluminant::A).
+To use this illuminant you need to enable the `cie-illuminants` feature on this crate.
 
 For example, to get the A illuminant's chromaticity:
 ```rust
+    # #[cfg(feature="cie-illuminants")]
+    # {
     use colorimetry::prelude::*;
 
     let xy_a = CIE1931.xyz(&StdIlluminant::A, None).chromaticity();
     // see <https://en.wikipedia.org/wiki/Standard_illuminant#Illuminant_A>
     approx::assert_abs_diff_eq!(xy_a.as_ref(), [0.44758, 0.40745].as_ref(), epsilon=1E-5)
+    # }
 ```
 
 Non-standard illuminants are represented by a `Illuminant`.

--- a/src/cct.rs
+++ b/src/cct.rs
@@ -384,14 +384,16 @@ fn test_cct(){
 }
 
 #[test]
-fn f1_test(){
+#[cfg(feature = "cie-illuminants")]
+fn f1_test() {
     let xyz_f1 = CIE1931.xyz_cie_table(&crate::std_illuminants::StdIlluminant::F1, None);
     // value from CIE Standard CIE15:2004 Table T8.1
     approx::assert_ulps_eq!(xyz_f1.cct().unwrap().t(), 6430.0, epsilon = 0.5);
 }
 
 #[test]
-fn f3_1_test(){
+#[cfg(feature = "cie-illuminants")]
+fn f3_1_test() {
     let xyz_f3_1 = CIE1931.xyz_cie_table(&crate::std_illuminants::StdIlluminant::F3_1, None);
     // value from CIE Standard CIE15:2004 Table T8.1    
     approx::assert_ulps_eq!(xyz_f3_1.cct().unwrap().t(), 2932.0, epsilon = 0.5);

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -156,6 +156,7 @@ mod cri_test {
     }
 
     #[test]
+    #[cfg(feature = "cie-illuminants")]
     fn cri_f1(){
         // should be all 100.0
         let cri0: CRI = StdIlluminant::F1.illuminant().try_into().unwrap();
@@ -164,6 +165,7 @@ mod cri_test {
     }
 
     #[test]
+    #[cfg(feature = "cie-illuminants")]
     fn cri_f3_1(){
         // 2932K, check with values as given in CIE15:2004 Table T.8.2
         let cri0: CRI = StdIlluminant::F3_1.illuminant().try_into().unwrap();
@@ -175,6 +177,7 @@ mod cri_test {
     }
 
     #[test]
+    #[cfg(feature = "cie-illuminants")]
     fn cri_f3_11(){
         // 5854K, check with values as given in CIE15:2004 Table T.8.2
         let cri0: CRI = StdIlluminant::F3_11.illuminant().try_into().unwrap();

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -600,8 +600,11 @@ mod xyz_test {
         approx::assert_ulps_ne!(xyz0, xyz2);
 
         // different observer
-        let xyz3 = XYZ::from_vecs(Vector3::zeros(), None, Observer::Std1964);
-        approx::assert_ulps_ne!(xyz0, xyz3);
+        #[cfg(feature="supplemental-observers")]
+        {
+            let xyz3 = XYZ::from_vecs(Vector3::zeros(), None, Observer::Std1964);
+            approx::assert_ulps_ne!(xyz0, xyz3);
+        }
 
     }
 }


### PR DESCRIPTION
Running `cargo test` produced a bunch of compilation errors. Some tests and examples assumed certain features were enabled, while they might not be. This PR fixes that by applying the conditional compilation guards needed.