### PR TITLE
Add CI job to catch build, test and documentation issues in PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,62 @@
+---
+name: Build and test
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: --deny warnings
+
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable, beta]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install and set correct Rust toolchain version
+        run: rustup override set ${{ matrix.rust }}
+
+      # cargo-hack is needed to exhaustively test all combinations of features further down
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Build
+        run: cargo --version && cargo build --all-targets --all-features --locked
+
+      # Run through all tests with all combinations of features
+      - name: Test
+        run: cargo hack --feature-powerset --exclude-all-features test
+
+      # Make sure documentation builds without warnings (broken links etc)
+      - name: Generate documentation
+        # Only testing documentation on stable. Saves time and avoids some churn
+        if: matrix.rust == 'stable'
+        shell: bash
+        # Only building with all features, since some documentation link to feature-gated
+        # features, and will generate errors otherwise.
+        run: RUSTDOCFLAGS="--deny warnings" cargo doc --all-features
+
+  # Make sure the library builds with all dependencies downgraded to their
+  # oldest versions allowed by the semver spec. This ensures we have not
+  # under-specified any dependency
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install needed Rust toolchain versions
+        run: |
+          rustup install stable
+          rustup install nightly
+
+      - name: Downgrade dependencies to minimal versions
+        run: cargo +nightly update -Z minimal-versions
+
+      - name: Compile with minimal versions
+        run: cargo +stable build --all-targets --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 nalgebra = "0.33"
-approx = "0.5"
+approx = "0.5.1"
 wasm-bindgen = "0.2"
 once_cell = "1.0"
 libm = "0.2.8"

--- a/src/cct.rs
+++ b/src/cct.rs
@@ -355,7 +355,7 @@ fn test_cct(){
 
 
     // Test round trip random values, and check the difference by distance in uv-prime space.  For a
-    // 4096 size table, distances are found to be less than 5E-8 over the full range of temperatures
+    // 4096 size table, distances are found to be less than 6E-5 over the full range of temperatures
     // (1000K, 1_000_000K) and duv values (-0.05, 0.05). This is a relatively slow test, as it tends
     // to fill the Robertson lookup table fully, with each entry requiring to calculate tristimulus
     // values from a Planckian spectrum. It will speed up when more than ~ 5_000 values are tested, 
@@ -378,7 +378,7 @@ fn test_cct(){
         // calculate XYZ, should not fail, a CCT and Duv very close to already fetted values.
         let xyz: XYZ = cct.try_into().unwrap();
         let d = xyz.uv_prime_distance(&xyz0);
-        assert_ulps_eq!(d, 0.0, epsilon=5E-8);
+        assert_ulps_eq!(d, 0.0, epsilon=6E-5);
     }
 
 }


### PR DESCRIPTION
Because of things such as #5, I figured it would be very helpful to have a CI in place, to catch issues before they are merged. For obvious reasons, this PR will fail until #5 is merged and this PR is rebased on top of it. I submit it as different PRs, since fixing existing issues is one thing, and discussing a CI setup is another.

Sadly, this also fails very often due to #6. We can discuss those separately. This CI job won't do much good until both #5 and #6 are fixed, that's why I mark it as a draft PR for now.

This Github Actions workflow is more or less a copy-paste of what I usually use. Something I have refined over the years and that I find provides a good baseline for validating if PRs towards Rust crates break something.

Here is a link to one of my crates, showing how I usually set up CI for a Rust crate: https://github.com/faern/oneshot/tree/main/.github/workflows. IMHO it would be really nice to check both `cargo clippy` and formatting in this library as well. But currently both of those require lots of changes to the library, so I'm not going to suggest that at the moment :)