### PR TITLE
Exhaustively try CCT space with an even spaced step instead of random samples

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Test
         run: cargo hack --feature-powerset --exclude-all-features test
 
+      - name: Run expensive CCT test
+        # Only run this expensive test on one platform.
+        # The code under test is not platform specific anyway.
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        shell: bash
+        # Run with optimizations (--release) to greatly speed up test run
+        run: cargo test --all-features --release test_cct_exhaustive -- --ignored
+
       # Make sure documentation builds without warnings (broken links etc)
       - name: Generate documentation
         # Only testing documentation on stable. Saves time and avoids some churn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,6 @@ dependencies = [
  "argmin-math",
  "clap",
  "colored",
- "getrandom",
  "js-sys",
  "libm",
  "nalgebra",
@@ -212,10 +211,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,6 @@ dependencies = [
  "nalgebra",
  "num-traits",
  "once_cell",
- "rand",
  "strum",
  "strum_macros",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ argmin = "0.10.0"
 argmin-math = "0.4.0"
 clap = { version = "4.5.18", features = ["derive"] }
 getrandom = { version = "0.2", features = ["js"] }
-rand = "0.8.5"
 colored = "2.2.0"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ munsell = []
 argmin = "0.10.0"
 argmin-math = "0.4.0"
 clap = { version = "4.5.18", features = ["derive"] }
-getrandom = { version = "0.2", features = ["js"] }
 colored = "2.2.0"
 
 [lib]

--- a/src/cct.rs
+++ b/src/cct.rs
@@ -375,20 +375,23 @@ fn compute_d_uv(mired: f64, d: f64) -> Option<f64> {
 // values from a Planckian spectrum. It will speed up when more than ~ 5_000 values are tested,
 // as the table will be completely calculated.
 #[test]
+#[ignore]
 fn test_cct_exhaustive() {
     const MIRED_START: f64 = 1.0;
     const MIRED_END: f64 = 1000.0;
-    const MIRED_STEP: f64 = 0.05;
+    const MIRED_STEP: f64 = 0.025;
 
-    const D_START: f64 = -0.05;
-    const D_END: f64 = 0.05;
-    const D_STEP: f64 = 0.005;
+    // Valid d range is supposed to be [-0.05, 0.05]. But for some values of `mired`, a `d`
+    // value close to the extremes can yield an error due to rounding when converting back
+    // and fourth between CCT and XYZ.
+    const D_START: f64 = -0.0499;
+    const D_END: f64 = 0.0499;
+    const D_STEP: f64 = 0.001;
 
     let mut mired = MIRED_START;
     while mired < MIRED_END {
-        // Make the d range exclusive in both ends, since it yields errors at the extremes
-        let mut d = D_START + D_STEP;
-        while d <= D_END - D_STEP {
+        let mut d = D_START;
+        while d <= D_END {
             if let Some(d_uv) = compute_d_uv(mired, d) {
                 assert_ulps_eq!(d_uv, 0.0, epsilon = 5.8E-5);
             }

--- a/src/cct.rs
+++ b/src/cct.rs
@@ -344,39 +344,68 @@ fn test_cct(){
     let xyz: XYZ = CCT(6000.0, -0.051).try_into().unwrap();
     let cct: Result<CCT,_> = xyz.try_into();
     assert_eq!(cct, Err(CmtError::CCTDuvLowError));
+}
 
+// Helper for tests computing the uv prime distance and verifying it's
+// withit acceptable limits.
+fn compute_d_uv(mired: f64, d: f64) -> Option<f64> {
+    let t = 1E6 / mired;
 
-    // Test round trip random values, and check the difference by distance in uv-prime space.  For a
-    // 4096 size table, distances are found to be less than 6E-5 over the full range of temperatures
-    // (1000K, 1_000_000K) and duv values (-0.05, 0.05). This is a relatively slow test, as it tends
-    // to fill the Robertson lookup table fully, with each entry requiring to calculate tristimulus
-    // values from a Planckian spectrum. It will speed up when more than ~ 5_000 values are tested, 
-    // as the table will be completely calculated.
+    // Get a CCT to test. Unwrap OK as range restricted above.
+    let cct0 = CCT::try_new(t, d).unwrap();
 
-    let seed: u64 = 27; // using a fixed seed, generating the same random numbers at every run.
-    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(seed);
+    // calculate XYZ0, skip value if not a valid point
+    let Ok(xyz0): Result<XYZ, _> = CCT::try_new(t, d).unwrap().try_into() else {
+        return None;
+    };
 
-    for i in 0..100 {
-      //  let mut rng = rand::thread_rng();
-        let mired = rand::Rng::gen_range(&mut rng, 1.0..1000.0); // mired temp
-        let t = 1E6/mired;
-        let d = rand::Rng::gen_range(&mut rng, -0.05..0.05);
-        
-        // Get a CCT to test. Unwrap OK as range restricted above.
-        let cct0  = CCT::try_new(t,d).unwrap();
+    // calculate the cct to test.
+    let cct: CCT = xyz0.try_into().unwrap();
 
-        // calculate XYZ0, skip value if not a valid point
-        let Ok(xyz0):Result<XYZ,_> = CCT::try_new(t,d).unwrap().try_into() else { continue;};
-        
-        // calculate the cct to test.
-        let cct: CCT = xyz0.try_into().unwrap();
+    // calculate XYZ, should not fail, a CCT and Duv very close to already fetted values.
+    let xyz: XYZ = cct.try_into().unwrap();
+    let d_uv = xyz.uv_prime_distance(&xyz0);
+    Some(d_uv)
+}
 
-        // calculate XYZ, should not fail, a CCT and Duv very close to already fetted values.
-        let xyz: XYZ = cct.try_into().unwrap();
-        let d = xyz.uv_prime_distance(&xyz0);
-        assert_ulps_eq!(d, 0.0, epsilon=6E-5);
+// Test round trip random values, and check the difference by distance in uv-prime space.  For a
+// 4096 size table, distances are found to be less than 5.8E-5 over the full range of temperatures
+// (1000K, 1_000_000K) and duv values (-0.05, 0.05). This is a relatively slow test, as it tends
+// to fill the Robertson lookup table fully, with each entry requiring to calculate tristimulus
+// values from a Planckian spectrum. It will speed up when more than ~ 5_000 values are tested,
+// as the table will be completely calculated.
+#[test]
+fn test_cct_exhaustive() {
+    const MIRED_START: f64 = 1.0;
+    const MIRED_END: f64 = 1000.0;
+    const MIRED_STEP: f64 = 0.05;
+
+    const D_START: f64 = -0.05;
+    const D_END: f64 = 0.05;
+    const D_STEP: f64 = 0.005;
+
+    let mut mired = MIRED_START;
+    while mired < MIRED_END {
+        // Make the d range exclusive in both ends, since it yields errors at the extremes
+        let mut d = D_START + D_STEP;
+        while d <= D_END - D_STEP {
+            if let Some(d_uv) = compute_d_uv(mired, d) {
+                assert_ulps_eq!(d_uv, 0.0, epsilon = 5.8E-5);
+            }
+            d += D_STEP;
+        }
+        mired += MIRED_STEP;
     }
+}
 
+/// Test the UV prime distance error at the worst case input values (empirically found).
+#[test]
+fn test_cct_at_max_error() {
+    let mired = 999.757;
+    let d = 0.0005;
+
+    let d_uv = compute_d_uv(mired, d).unwrap();
+    assert_ulps_eq!(d_uv, 0.0, epsilon = 5.8E-5);
 }
 
 #[test]


### PR DESCRIPTION
Follow up to #6.

Commit 317bd34 stopped testing the mired/d search space randomly and instead probed 100 fixed points generated by a PRNG with a fixed seed. This makes it hard to see what points are probed, and why these specific points were chosen. It's always the same 100 values, but the values are not obvious in the code. Not to mention that it costs having `rand` as a `dev-dependency` even though no real randomness was needed.

This PR takes a stab at trying to simplify this test. It essentially does two things:

1. Empirically find roughly where in the search space the error is the highest. Create one dedicated test for this point, to make sure it stays within the error margin.
2. Replace the test for 100 "random" probe points with going over the entire search space, in discrete steps, checking that no point in it has a too high error.
