### PR TITLE
Reduce allocation by working directly on arrays instead of `collect()`ing

### DIFF
--- a/src/cri.rs
+++ b/src/cri.rs
@@ -79,13 +79,9 @@ impl TryFrom<&Illuminant> for CRI {
         let illuminant = &illuminant.clone().set_illuminance(&CIE1931, 100.0);
         // Calculate Device Under Test (dut) XYZ illuminant and sample values
         let xyz_dut = CIE1931.xyz_from_spectrum(illuminant, None);
-        let xyz_dut_samples: [XYZ; N_TCS] = 
-            TCS
-                .iter()
-               // .map(|colorant|CIE1931.xyz_of_sample_with_illuminant(illuminant, colorant))
-                .map(|colorant|CIE1931.xyz(illuminant, Some(colorant)))
-                .collect::<Vec<XYZ>>()
-                .try_into().unwrap();
+        let xyz_dut_samples: [XYZ; N_TCS] = TCS
+            .each_ref()
+            .map(|colorant| CIE1931.xyz(illuminant, Some(colorant)));
 
         // Determine reference color temperarture value
         let cct_dut = xyz_dut.cct()?.t();
@@ -98,14 +94,9 @@ impl TryFrom<&Illuminant> for CRI {
 
         // Calculate the reference illuminant values
         let xyz_ref = CIE1931.xyz_from_spectrum(&illuminant_ref, None);
-        let xyz_ref_samples: [XYZ; N_TCS] = 
-            TCS
-                .iter()
-              //  .map(|sample|CIE1931.xyz_of_sample_with_illuminant(&illuminant_ref, sample))
-                .map(|sample|CIE1931.xyz(&illuminant_ref, Some(sample)))
-                .collect::<Vec<XYZ>>()
-                .try_into().unwrap();
-        
+        let xyz_ref_samples: [XYZ; N_TCS] = TCS
+            .each_ref()
+            .map(|colorant| CIE1931.xyz(&illuminant_ref, Some(colorant)));
 
         let cdt = cd(xyz_dut.uv60());
         let cdr = cd(xyz_ref.uv60());

--- a/src/rgbspace.rs
+++ b/src/rgbspace.rs
@@ -120,8 +120,7 @@ impl RgbSpaceData {
         PRIMARY_FILTERS.get_or_init(||{
             let white = self.white.illuminant().clone().set_illuminance(&CIE1931, 100.0).0;
             // RGB primaries defined with reference to CIE1931, and 100 cd/m2.
-            let sv:  Vec<Spectrum> = self.primaries.iter().map(|v|&v.0/&white).collect();
-            let sa: [Spectrum;3] = sv.try_into().unwrap();
+            let sa = self.primaries.each_ref().map(|v| &v.0 / &white);
             sa.map(|v|Colorant(v))
         })
     }

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -108,7 +108,10 @@ impl XYZ {
     /// assert_ulps_eq!(z, 108.861_036, epsilon = 1E-6);
     /// ```
     pub fn values(&self) -> [f64; 3] {
-        (*self).into()
+        let xyz_matrix = self.xyz.unwrap_or(self.xyzn);
+        let s = 100.0 / self.xyzn.y;
+        let xyz_array: [f64; 3] = *xyz_matrix.as_ref();
+        xyz_array.map(|v| v * s)
     }
 
     /// Set the illuminance of an illuminant, either for an illuminant directly,
@@ -304,11 +307,8 @@ impl AsRef<[f64;3]> for XYZ {
 /// if present, in case of stimulus values. Else, in case of illuminants only, normalized to
 /// a y value of 100.
 impl From<XYZ> for [f64;3] {
-    fn from(xyz0: XYZ) -> Self {
-        let xyz = xyz0.xyz.unwrap_or(xyz0.xyzn);
-        let s = 100.0/xyz0.xyzn.y;
-        let xyz_array: [f64; 3] = *xyz.as_ref();
-        xyz_array.map(|v| v * s)
+    fn from(xyz: XYZ) -> Self {
+        xyz.values()
     }
 }
 

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -312,12 +312,6 @@ impl From<XYZ> for [f64;3] {
     }
 }
 
-impl From<&XYZ> for [f64;3] {
-    fn from(xyz0: &XYZ) -> Self {
-        xyz0.clone().into()
-    }
-}
-
 impl AbsDiffEq for XYZ {
     type Epsilon = f64;
 

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -301,13 +301,14 @@ impl AsRef<[f64;3]> for XYZ {
  */
 
 /// Get normalized tristimulus values as an array. Normalized to the reference white luminance value yn
-/// if present, in case of stimulus values.  Else, in case of illuminants only, normalized to
+/// if present, in case of stimulus values. Else, in case of illuminants only, normalized to
 /// a y value of 100.
 impl From<XYZ> for [f64;3] {
     fn from(xyz0: XYZ) -> Self {
         let xyz = xyz0.xyz.unwrap_or(xyz0.xyzn);
         let s = 100.0/xyz0.xyzn.y;
-        xyz.into_iter().map(|&v|s*v).collect::<Vec<f64>>().try_into().unwrap()
+        let xyz_array: [f64; 3] = *xyz.as_ref();
+        xyz_array.map(|v| v * s)
     }
 }
 


### PR DESCRIPTION
I found a few places in the code that followed the pattern: array with size known at compile time -> iterate over (loses known length) -> allocate result to heap -> try to convert back to array with the same size. Since the size is known at compile time, it can quite often be processed in place while keeping the known length.

The benefits this PR brings includes reducing heap allocation. There are no benchmarks, but I suspect this is noticeably faster. It also removes a panicking code path. I have not checked if the compiler can optimize the possible panic or not from the previous version of the code though. I also think this code is simpler (subjective), and shorter.

Most of the trick here is `array::as_ref` which allows us to `map` over an array without being able to own the array.

I also swapped the code between `XYZ::values` and `From<XYZ> for [f64;3]`. One was calling the other, and the functionality remains the same as before. But I think this is a bit easier to follow. `xyz.values()` is easier to know what it does, compared to `(*self).into()`. My personal opinion is that it's good to avoid `.into()` quite often, as it is hard to follow what conversion implementation is actually called.