### PR TITLE
Make `XYZ::new` take arrays instead of slices

### DIFF
--- a/src/cam.rs
+++ b/src/cam.rs
@@ -152,7 +152,7 @@ impl CieCam16 {
         let rgb = rgb_p.component_div(&d_rgb_vec);
 
         let xyz = M16INV * rgb;
-        Ok(XYZ::new(xyzn.as_ref(), Some(xyz.as_ref()), self.observer))
+        Ok(XYZ::from_vecs(xyzn, Some(xyz), self.observer))
 
     }
 
@@ -254,7 +254,7 @@ mod cam_test {
     #[test]
     fn test_worked_example(){
         // see section 7 CIE 248:2022
-        let xyz = XYZ::new(&[96.46, 100.0, 108.62], Some(&[60.70, 49.60, 10.29]), Observer::Std1931);
+        let xyz = XYZ::new([96.46, 100.0, 108.62], Some([60.70, 49.60, 10.29]), Observer::Std1931);
         let vc = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
         let cam = CieCam16::new(xyz, vc).unwrap();
         let &[j,c,h] = cam.jch.as_ref();

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -2,7 +2,7 @@ use core::f64;
 use std::ops::Add;
 
 use approx::{ulps_eq, AbsDiffEq};
-use nalgebra::Vector3;
+use nalgebra::{ArrayStorage, Vector3};
 use crate::{
     geometry::{LineAB, Orientation},
     observer::{self, Observer},
@@ -15,10 +15,9 @@ use crate::{
 use wasm_bindgen::prelude::wasm_bindgen; 
 
 
-const D65A: [f64;3] = [95.04, 100.0, 108.86];
-pub const XYZ_D65: XYZ = XYZ::new(&D65A, None, Observer::Std1931);
-pub const XYZ_D65WHITE: XYZ = XYZ::new(&D65A, Some(&D65A), Observer::Std1931);
-
+const D65A: [f64; 3] = [95.04, 100.0, 108.86];
+pub const XYZ_D65: XYZ = XYZ::new(D65A, None, Observer::Std1931);
+pub const XYZ_D65WHITE: XYZ = XYZ::new(D65A, Some(D65A), Observer::Std1931);
 
 #[wasm_bindgen]
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
@@ -39,11 +38,11 @@ impl XYZ {
 
     /// Define a set of [XYZ]-values directly, using an identifier for its
     /// associated observer, such as [Observer::Std1931] or [Observer::Std2015].
-    /// 
-    pub const fn new(xyzn: &[f64], xyz: Option<&[f64]>, observer: Observer) -> Self {
-        let xyzn = Vector3::<f64>::new(xyzn[0], xyzn[1], xyzn[2]);
+    ///
+    pub const fn new(xyzn: [f64; 3], xyz: Option<[f64; 3]>, observer: Observer) -> Self {
+        let xyzn = Vector3::<f64>::from_array_storage(ArrayStorage([xyzn]));
         let xyz = if let Some(xyz) = xyz {
-            Some(Vector3::<f64>::new(xyz[0], xyz[1], xyz[2]))
+            Some(Vector3::<f64>::from_array_storage(ArrayStorage([xyz])))
         } else {
             None
         };
@@ -119,11 +118,11 @@ impl XYZ {
     /// const D65A: [f64;3] = [95.04, 100.0, 108.86];
     ///
     /// let d65_xyz = CIE1931.xyz(&StdIlluminant::D65, None).set_illuminance(100.0);
-    /// assert_ulps_eq!(d65_xyz, XYZ::new(&D65A, None, Observer::Std1931), epsilon = 1E-2);
-    /// 
+    /// assert_ulps_eq!(d65_xyz, XYZ::new(D65A, None, Observer::Std1931), epsilon = 1E-2);
+    ///
     /// let d65_xyz_sample = CIE1931.xyz(&StdIlluminant::D65, Some(&Colorant::white()));
-    /// 
-    /// assert_ulps_eq!(d65_xyz_sample, XYZ::new(&D65A, Some(&D65A), Observer::Std1931), epsilon = 1E-2);
+    ///
+    /// assert_ulps_eq!(d65_xyz_sample, XYZ::new(D65A, Some(D65A), Observer::Std1931), epsilon = 1E-2);
     /// ```
     pub fn set_illuminance(mut self, illuminance: f64) -> Self {
         let s = illuminance/self.xyzn.y;


### PR DESCRIPTION
Previously if a slice of len < 3 was passed in, the constructor would panic. If a slice of len > 3 was passed in, all elements after the third would just be silently ignored. This seems lossy and error prone.

If requirements can be encoded in the type system (without introducing a lot of unergonomic APIs), then they should IMO. This allows the compiler to catch more problems with the code, and just the function signatures themselves tell the reader a lot more about what is expected from the API.

`XYZ::new` is now truly infallible and it will use all the passed in data.

If construction from slices are needed to make the API more ergonomic, it can be added! But I did not know of any use case where this would be really helpful, so I did not add one for now. If one is added I think it should be a fallible method that returns a proper error if the length of passed in slices is not three elements long.