### PR TITLE
Fix some clippy warnings

### DIFF
--- a/examples/cri.rs
+++ b/examples/cri.rs
@@ -8,7 +8,6 @@ use strum::IntoEnumIterator;
 /// Prints the standard illuminants in the library, with their elated color temperature, with
 /// parameters distance to the Planckian, the general Color Rendering Index Ra, and the spectal
 /// color rendering index R9.
-
 fn main() -> Result<(), Box<dyn std::error::Error>>{
     for  spc in StdIlluminant::iter() {
 

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -34,8 +34,6 @@ pub struct CieCam16 {
 impl CieCam16 {
 
     /// CIECAM16 coordinates for a particular set of viewing conditions.
-    /// 
-
     fn new(xyz: XYZ, vc: ViewConditions) -> Result<Self, CmtError> {
         let xyz0= xyz.xyz.ok_or(CmtError::NoColorant)?;
         let xyzn0 = xyz.xyzn;

--- a/src/cct.rs
+++ b/src/cct.rs
@@ -257,7 +257,7 @@ pub fn robertson_table(im: usize) -> &'static [f64;3] {
 }
 
 fn im2t(im: usize) -> f64 {
-    1E6/( 1.0 + ((((MIRED_MAX-1)*im)) as f64) / ((N_STEPS-1) as f64)) 
+    1E6/( 1.0 + (((MIRED_MAX-1)*im) as f64) / ((N_STEPS-1) as f64))
 }  
 
 #[test]

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -224,9 +224,10 @@ impl Mul<&Colorant> for &Colorant {
     /// approx::assert_abs_diff_eq!(r,b);
     /// ```
     fn mul(self, rhs: &Colorant) -> Self::Output {
-        Colorant(&self.0 * &rhs.0) // use spectrum multiplication
+        Colorant(self.0 * rhs.0) // use spectrum multiplication
     }
 }
+
 impl AddAssign<&Self> for Colorant {
     fn add_assign(&mut self, rhs: &Self) {
         self.0 += rhs.0 // use spectral multiplication

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -92,7 +92,7 @@ impl TryFrom<&[f64]> for Colorant {
     type Error = CmtError;
 
     fn try_from(data: &[f64]) -> Result<Self, Self::Error> {
-        if data.iter().any(|&v|v<0.0 || v>1.0){
+        if data.iter().any(|v| !(0.0..=1.0).contains(v)){
             Err(CmtError::OutOfRange { name: "Colorant Spectral Value".into(), low: 0.0, high: 1.0 })
         } else {
             let spectrum = Spectrum::try_from(data)?;

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -14,7 +14,7 @@ impl GammaCurve{
 
     // from rgb coordinates to xyz, gamma > 1.0
     pub fn decode(&self, x: f64) -> f64 { 
-        if x<0.0 || x>1.0 { 
+        if !(0.0..=1.0).contains(&x) {
             f64::NAN
         } else {
             match self.p.len() {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -276,7 +276,7 @@ fn triangle_test() {
 /// in arbitrary space dimension. Typically used in two or three
 /// dimensional spaces.
 pub fn distance(p: &[f64], q: &[f64]) -> f64 {
-    let s2 = p.into_iter().zip(q).fold(0.0, |s,(&pi, &qi)|s + (pi - qi).powi(2));
+    let s2 = p.iter().zip(q).fold(0.0, |s,(&pi, &qi)|s + (pi - qi).powi(2));
     s2.sqrt()
 }
 #[test]

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -234,8 +234,7 @@ impl Triangle {
 
     pub fn within(&self, x:f64, y:f64) -> bool {
         let abc = self.barycentric_coordinates(x, y);
-        !abc.into_iter().any(|v|v<0.0 || v>1.0)
-
+        !abc.iter().any(|v| !(0.0..=1.0).contains(v))
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -276,7 +276,7 @@ fn triangle_test() {
 /// in arbitrary space dimension. Typically used in two or three
 /// dimensional spaces.
 pub fn distance(p: &[f64], q: &[f64]) -> f64 {
-    let s2 = p.into_iter().zip(q.into_iter()).fold(0.0, |s,(&pi, &qi)|s + (pi - qi).powi(2));
+    let s2 = p.into_iter().zip(q).fold(0.0, |s,(&pi, &qi)|s + (pi - qi).powi(2));
     s2.sqrt()
 }
 #[test]

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -137,7 +137,7 @@ impl Illuminant {
     }
 
     pub fn d_illuminant(cct: f64) -> Result<Illuminant, CmtError> {
-        if cct<4000.0 || cct>25000.0 {
+        if !(4000.0..=25000.0).contains(&cct) {
             Err(CmtError::OutOfRange{name:"CIE D Illuminant Temperature".to_string(), low: 4000.0, high: 25000.0})
         } else { 
             let xd = match cct {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -38,9 +38,6 @@ impl CieLab {
     }
      */
 
-    /**
-     * 
-     */
     pub fn delta_e(&self, other: &Self) -> Result<f64, CmtError> {
         if ulps_eq!(self.xyzn, other.xyzn) {
             let &[l1, a1, b1] = self.lab.as_ref();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@
 #![allow(dead_code, unused_variables, unused_imports, )]
 #![doc = include_str!("../README.md")]
 
-
+// This library contains lots and lots of float constants for colorimetry.
+// If clippy finds a constant that is close to one of the well known standard library
+// constanst, it will complain by default. This yields a lot of false positives.
+#![allow(clippy::approx_constant)]
 
 
 pub mod cam;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -72,7 +72,7 @@ use nalgebra::{Matrix3, SMatrix, Vector3};
 use crate::{
     lab::CieLab, 
     physics::{planck, planck_slope, to_wavelength}, 
-    spectrum::{Spectrum, NS}, 
+    spectrum::{Spectrum, NS, SPECTRUM_WAVELENGTH_RANGE},
     xyz::XYZ, 
     error::CmtError, 
     colorant::Colorant, 
@@ -351,7 +351,7 @@ impl ObserverData {
     pub fn spectral_locus_by_nm(&self, l: usize) -> Result<XYZ, CmtError> {
         let min = self.spectral_locus_nm_min();
         let max = self.spectral_locus_nm_max();
-        if l<380 || l>780 {
+        if !SPECTRUM_WAVELENGTH_RANGE.contains(&l) {
             return Err(CmtError::WavelengthOutOfRange);
         };
         if l<min || l>max {

--- a/src/rgbspace.rs
+++ b/src/rgbspace.rs
@@ -121,7 +121,7 @@ impl RgbSpaceData {
             let white = self.white.illuminant().clone().set_illuminance(&CIE1931, 100.0).0;
             // RGB primaries defined with reference to CIE1931, and 100 cd/m2.
             let sa = self.primaries.each_ref().map(|v| &v.0 / &white);
-            sa.map(|v|Colorant(v))
+            sa.map(Colorant)
         })
     }
 

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -129,7 +129,6 @@ impl Spectrum {
     /// [The Interpolation Method of Sprague-Karup](https://www.sciencedirect.com/science/article/pii/0771050X75900273)
     /// for the description of the method.
     /// This implementation uses end-point values for extrapolation, as recommended by CIE15:2004 7.2.2.1.
-    
     pub fn sprague_interpolate(wavelengths: [f64;2], data: &[f64]) ->Result<Self, CmtError> {
         let data = sprinterp(wavelengths.try_into().unwrap(), data)?;
         Ok(Self(SVector::<f64, 401>::from_array_storage(nalgebra::ArrayStorage([data]))))

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -9,7 +9,7 @@ and painted patches, is represented by the [Spectrum]-object in this library.
 The spectral sensitivity of human vision is described by an [`Observer`](crate::observer::Observer).
 */
 use core::f64;
-use std::{borrow::Cow, collections::BTreeMap, default, error::Error, iter::Sum, ops::{Add, AddAssign, Deref, Div, Index, IndexMut, Mul, MulAssign}};
+use std::{borrow::Cow, collections::BTreeMap, default, error::Error, iter::Sum, ops::{Add, AddAssign, Deref, Div, Index, IndexMut, Mul, MulAssign, RangeInclusive}};
 
 use approx::{AbsDiff, AbsDiffEq};
 use num_traits::ToPrimitive;
@@ -30,10 +30,14 @@ use crate::{
     rgb::RGB
 };
 
+/// The wavelength range of the spectrums supported by this library.
+///
+/// From 380 to 780 nanometers, inclusive in both ends.
+pub const SPECTRUM_WAVELENGTH_RANGE: RangeInclusive<usize> = 380..=780;
 
-// Standard Spectrum domain ranging from 380 to 780 nanometer,
-// with 401 values.
-pub const NS: usize = 401;
+/// Number of values in the spectrum. This is 401.
+pub const NS: usize = *SPECTRUM_WAVELENGTH_RANGE.end() - *SPECTRUM_WAVELENGTH_RANGE.start() + 1;
+
 
 /**
 This container holds spectral values within a wavelength domain ranging from 380
@@ -444,11 +448,10 @@ impl Index<usize> for Spectrum {
     type Output = f64;
 
     fn index(&self, i: usize) -> &Self::Output {
-        if i<380 || i>780 {
+        if !SPECTRUM_WAVELENGTH_RANGE.contains(&i) {
             &f64::NAN
         } else {
-            &self.0[(i-380,0)]
-
+            &self.0[(i - SPECTRUM_WAVELENGTH_RANGE.start(), 0)]
         }
     }
 }

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -182,7 +182,7 @@ impl TryFrom<&[f64]> for Spectrum {
         if data.len()!=NS {
             Err(CmtError::DataSize401Error)
         } else {
-            Ok(Self(SVector::<f64, NS>::from_iterator(data.into_iter().copied())))
+            Ok(Self(SVector::<f64, NS>::from_iterator(data.iter().copied())))
         }
     }
 }

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -134,7 +134,7 @@ impl Spectrum {
     /// for the description of the method.
     /// This implementation uses end-point values for extrapolation, as recommended by CIE15:2004 7.2.2.1.
     pub fn sprague_interpolate(wavelengths: [f64;2], data: &[f64]) ->Result<Self, CmtError> {
-        let data = sprinterp(wavelengths.try_into().unwrap(), data)?;
+        let data = sprinterp(wavelengths, data)?;
         Ok(Self(SVector::<f64, 401>::from_array_storage(nalgebra::ArrayStorage([data]))))
     }
 
@@ -155,7 +155,6 @@ impl Spectrum {
                 ::from_iterator(
                     (2*sd3+1) as usize,
                     (-sd3..=sd3)
-                        .into_iter()
                         .map(|i| gaussian_peak_one(i as f64, 0.0, sigma)
                     ));
 
@@ -491,7 +490,7 @@ fn linterp(mut wl: [f64;2], data: &[f64]) -> Result<[f64;NS], CmtError> {
     spd.iter_mut().enumerate().for_each(|(i,v)|{
         let l = (i + 380) as f64 * 1E-9; // wavelength in meters
         let t = ((l-wl)/(wh - wl)).clamp(0.0, 1.0); // length parameter
-        let tf = (t * dlm1 as f64);
+        let tf = t * dlm1 as f64;
         let j = tf.trunc() as usize;
         let f = tf.fract();
         if j >= dlm1 {

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -491,7 +491,7 @@ fn linterp(mut wl: [f64;2], data: &[f64]) -> Result<[f64;NS], CmtError> {
     spd.iter_mut().enumerate().for_each(|(i,v)|{
         let l = (i + 380) as f64 * 1E-9; // wavelength in meters
         let t = ((l-wl)/(wh - wl)).clamp(0.0, 1.0); // length parameter
-        let tf = (t * dlm1 as f64) as f64;
+        let tf = (t * dlm1 as f64);
         let j = tf.trunc() as usize;
         let f = tf.fract();
         if j >= dlm1 {

--- a/src/std_illuminants.rs
+++ b/src/std_illuminants.rs
@@ -22,20 +22,7 @@ on Wikipedia.  Instead of a dash, use the `_` character to access these
 illuminants by their name here, so use `StdIlluminant::LED_BH1` to use the
 phosphor-converted Blue LED and Red LED standard illuminant.
 The Fluorescent `F3_X` series is included here, with X ranging from 1 to 15.
-*/
 
-use std::{borrow::Cow, ops::Deref, vec};
-use nalgebra::{ArrayStorage, SMatrix};
-use wasm_bindgen::prelude::*;
-use crate::{
-    error::CmtError,
-    spectrum::Spectrum,
-    traits::Light,
-    illuminant::Illuminant,
-    spectrum::NS
-};
-
-/**
 The CIE Standard Illuminants, available in the library, defined as enums.
 
 The illuminants D65 and D50 are always included in this library, all the others will be only
@@ -51,9 +38,18 @@ A static reference to the spectra can be obtained using the "spectrum" method.
         println!{"{spc}"};
     }
 ```
+*/
 
- */
-
+use std::{borrow::Cow, ops::Deref, vec};
+use nalgebra::{ArrayStorage, SMatrix};
+use wasm_bindgen::prelude::*;
+use crate::{
+    error::CmtError,
+    spectrum::Spectrum,
+    traits::Light,
+    illuminant::Illuminant,
+    spectrum::NS
+};
 
 
 // This macro generates the `StdIlluminant` enumerator, representing the standard illuminants

--- a/src/viewconditions.rs
+++ b/src/viewconditions.rs
@@ -48,13 +48,7 @@ impl ViewConditions {
     /// Hyperbolic post-adaptation response compression function
     /// 
     /// As used in CIECAM02 and CAM16
-    /*
-    pub fn lum_adapt(&self, v: &mut f64) {
-        let t = (self.f_l() * *v / 100.).powf(0.42);
-        *v = v.signum() * 400. * t / (27.13 + t) + 0.1;
-    }
-     */
-
+    ///
     /// Modified hyperbolic post-adaptation response compression function
     /// 
     /// Updated to fix some issues with the function as used in CIECAM02 and CAM16.


### PR DESCRIPTION
Clippy is a great Rust linter. It's part of the standard distribution of Rust. It can really help find bugs, code smells and unidiomatic code. I ran it against this library and fixed some of the things it picked up on. I did not fix all of its warnings in order to keep the PR size down a bit at least, and because I don't have more time right now :)

I hope we can fix all clippy warnings, and then add a CI check to enforce no lint warnings in the code :sparkles: 

This PR is probably easiest reviewed per commit. Since each commit deal with one clippy warning, and they are not related to each other. Too read more about all lint rules and why they are the way they are, you can check them out here: https://rust-lang.github.io/rust-clippy/master/index.html