### PR TITLE
Fix more clippy warnings

### DIFF
--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -104,7 +104,7 @@ impl Illuminant {
     // Also overwrite spectrum type to Illuminant
     pub fn set_irradiance(mut self, irradiance: f64) -> Self {
         let s = irradiance/self.0.0.sum();
-        self.0.0.iter_mut().for_each(|v|*v = *v *s);
+        self.0.0.iter_mut().for_each(|v| *v *= s);
         self
     }
 
@@ -116,7 +116,7 @@ impl Illuminant {
 
     pub fn set_illuminance(mut self, obs: &ObserverData, illuminance: f64) -> Self {
         let l = illuminance / (obs.data.row(1) *  self.0.0 * obs.lumconst).x;
-        self.0.0.iter_mut().for_each(|v| *v = *v * l);
+        self.0.0.iter_mut().for_each(|v| *v *= l);
         self
     }
 

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -538,7 +538,7 @@ mod obs_test {
             observer
         } = CIE1931.xyz_cie_table(&StdIlluminant::D65, Some(100.0));
         approx::assert_ulps_eq!(xyzn, na::Vector3::new(95.04, 100.0, 108.86), epsilon=1E-2);
-        assert!(xyz == None);
+        assert!(xyz.is_none());
     }
     
     #[test]

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -386,7 +386,7 @@ impl ObserverData {
                     (0, _)  => break 0,
                     (1.., d) if d> -f64::EPSILON => break m,
                     _ => {
-                        m = m - 1;
+                        m -= 1;
                         lp = l;
                     }
                 }
@@ -414,7 +414,7 @@ impl ObserverData {
                     (400, _)  => break 400,
                     (..400, d) if d< f64::EPSILON => break m-1,
                     _ => {
-                        m = m + 1;
+                        m += 1;
                         lp = l;
                     }
                 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -168,7 +168,7 @@ impl Light for RGB {
             .fold(
                 Spectrum::default(),
                 |acc, ((&v,&w),s)| {
-                    acc + v * w * &s.0
+                    acc + v * w * s.0
                 }
             );
         Cow::Owned(s)
@@ -200,7 +200,7 @@ impl Filter for RGB {
             .fold(
                 Spectrum::default(),
                 |acc, ((&v,&w),s)| {
-                    acc + v * w * &s.0
+                    acc + v * w * s.0
                 }
             );
         Cow::Owned(s)

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -317,8 +317,9 @@ impl Spectrum {
 }
 
 
-// Multiplication of two spectra using the `*`-operator, typically for a combinations of an illuminant and a colorant
-// or when combining multiple ColorPatchs or filters. Subtractive Mixing.
+/// Multiplication of two spectra using the `*`-operator, typically for a combinations of an
+/// illuminant and a colorant or when combining multiple ColorPatchs or filters.
+/// Subtractive Mixing.
 impl Mul for Spectrum {
     type Output = Self;
 
@@ -384,8 +385,8 @@ impl <'a> From<&'a Spectrum> for Cow<'a, Spectrum> {
 }
 
 
-// Addition of spectra, typically used for illuminant (multiple sources).
-// Additive mixing
+/// Addition of spectra, typically used for illuminant (multiple sources).
+/// Additive mixing
 impl Add for Spectrum {
     type Output = Self;
 
@@ -395,8 +396,8 @@ impl Add for Spectrum {
     }
 }
 
-// Addition of spectra, typically used for illuminant (multiple sources).
-// Additive mixing
+/// Addition of spectra, typically used for illuminant (multiple sources).
+/// Additive mixing
 impl Add for &Spectrum {
     type Output = Spectrum;
 
@@ -407,16 +408,16 @@ impl Add for &Spectrum {
     }
 }
 
-// Addition of spectra, typically used for illuminant (multiple sources).
-// Additive mixing
+/// Addition of spectra, typically used for illuminant (multiple sources).
+/// Additive mixing
 impl AddAssign for Spectrum {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0
     }
 }
 
-// Addition of spectra, typically used for illuminant (multiple sources).
-// Additive mixing
+/// Addition of spectra, typically used for illuminant (multiple sources).
+/// Additive mixing
 impl AddAssign<&Spectrum> for Spectrum {
     fn add_assign(&mut self, rhs: &Self) {
         self.0 += rhs.0

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -660,7 +660,7 @@ mod tests {
     #[test]
     fn d65() {
         let [x, y ] = CIE1931.xyz_from_spectrum(
-            &&Illuminant::d65().set_illuminance(&CIE1931, 100.0), None).chromaticity();
+            &Illuminant::d65().set_illuminance(&CIE1931, 100.0), None).chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(x, 0.312_72, epsilon = 5E-5);
         assert_ulps_eq!(y, 0.329_03, epsilon = 5E-5);

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -798,8 +798,8 @@ mod tests {
         const NF: i32 = 20;
         const NT: i32 = NF * 10;
         let wl = [380.0, 780.0];
-        let data: Vec<f64> = (-NF..=NF).into_iter().map(|i|((i as f64/(NF as f64))*1.5*PI).tanh()).collect();
-        let data_want: Vec<f64> = (-NT..=NT).into_iter().map(|i|((i as f64/(NT as f64))*1.5*PI).tanh()).collect();
+        let data: Vec<f64> = (-NF..=NF).map(|i|((i as f64/(NF as f64))*1.5*PI).tanh()).collect();
+        let data_want: Vec<f64> = (-NT..=NT).map(|i|((i as f64/(NT as f64))*1.5*PI).tanh()).collect();
         let tinterpolate = sprinterp(wl, &data).unwrap();
         tinterpolate.iter().zip(data_want.iter()).for_each(|(&v, w)|approx::assert_ulps_eq!(v, w, epsilon=1E-4));
     }
@@ -807,7 +807,7 @@ mod tests {
     #[test]
     fn sprague_sin() {
         let wl = [380.0, 780.0];
-        let data: Vec<f64> = (0..=80).into_iter().map(|i|{
+        let data: Vec<f64> = (0..=80).map(|i|{
             let x = i as f64/80.0;
             (x*PI).sin()
         }).collect();

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -24,7 +24,7 @@ impl Deref for Stimulus {
 impl Stimulus {
     pub fn set_luminance(mut self, obs: &ObserverData, luminance: f64) -> Self {
         let l = luminance / (obs.data.row(1) *  self.0.0 * obs.lumconst).x;
-        self.0.0.iter_mut().for_each(|v| *v = *v * l);
+        self.0.0.iter_mut().for_each(|v| *v *= l);
         self
     }
 

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -129,10 +129,10 @@ impl XYZ {
     /// ```
     pub fn set_illuminance(mut self, illuminance: f64) -> Self {
         let s = illuminance/self.xyzn.y;
-        self.xyzn.iter_mut().for_each(|v|*v = *v * s);
+        self.xyzn.iter_mut().for_each(|v| *v *= s);
         if let Some(xyz0) = &mut self.xyz {
             // colorant with illuminant
-            xyz0.iter_mut().for_each(|v|*v = *v * s)
+            xyz0.iter_mut().for_each(|v| *v *= s)
          };
         self
     }


### PR DESCRIPTION
PR tightly related to #13. Just another batch of Clippy warnings fixed. Again, the lint name that is being addressed can be found in each commit message, and the documentation for that lint can be found at https://rust-lang.github.io/rust-clippy/master/index.html

The last commit is unrelated to Clippy. I found some helpful comments that would be great to see in the docs, so I made them doc comments (`//` -> `///`)