### PR TITLE
Clearer colorant to spectrum conversion

### DIFF
--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -165,30 +165,40 @@ impl DerefMut for Colorant {
     }
 }
 
+/// Adds together the spectrums of two colorants, resulting in a new colorant.
+///
+/// The result is clamped to the valid colorant range of 0.0 to 1.0.
 impl Add for Colorant {
     type Output = Self;
 
-    /// Adds two colorants
     fn add(self, rhs: Self) -> Self::Output {
-        let mut r = self.0 + rhs.0;
-        r.clamp(0.0, 1.0);
-        Colorant(r)
+        let mut spectrum = self.0 + rhs.0;
+        spectrum.clamp(0.0, 1.0);
+        Colorant(spectrum)
     }
 }
 
+/// Multiply the spectrum of a colorant with a scalar value.
+///
+/// The result is clamped to the valid colorant range of 0.0 to 1.0.
 impl Mul<f64> for Colorant {
     type Output = Self;
 
     fn mul(self, rhs: f64) -> Self::Output {
-        Self(self.0 * rhs)
+        let mut spectrum = self.0 * rhs;
+        spectrum.clamp(0.0, 1.0);
+        Self(spectrum)
     }
 }
 
+/// Multiply the spectrum of a colorant with a scalar value.
+///
+/// The result is clamped to the valid colorant range of 0.0 to 1.0.
 impl Mul<Colorant> for f64 {
     type Output = Colorant;
 
     fn mul(self, rhs: Colorant) -> Self::Output {
-        Colorant(self * rhs.0)
+        rhs.mul(self)
     }
 }
 
@@ -228,9 +238,13 @@ impl Mul<&Colorant> for &Colorant {
     }
 }
 
+/// Add the spectrum of a colorant to this colorant.
+///
+/// The result is clamped to the valid colorant range of 0.0 to 1.0.
 impl AddAssign<&Self> for Colorant {
     fn add_assign(&mut self, rhs: &Self) {
-        self.0 += rhs.0 // use spectral multiplication
+        self.0 += rhs.0;
+        self.0.clamp(0.0, 1.0);
     }
 }
 

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -41,18 +41,18 @@ impl Colorant {
     /// # use approx::assert_ulps_eq;
     /// use colorimetry::prelude::*;
     /// let colorant = Colorant::top_hat(550.0, 1.0);
-    /// let bandfilter: &[f64; NS] = colorant.as_ref();
-    /// assert_ulps_eq!(bandfilter[549-380], 0.0);
-    /// assert_ulps_eq!(bandfilter[550-380], 1.0);
-    /// assert_ulps_eq!(bandfilter[551-380], 0.0);
+    /// let bandfilter = colorant.spectrum();
+    /// assert_ulps_eq!(bandfilter[549], 0.0);
+    /// assert_ulps_eq!(bandfilter[550], 1.0);
+    /// assert_ulps_eq!(bandfilter[551], 0.0);
     ///
     /// let colorant = Colorant::top_hat(550.0, 2.0);
-    /// let bandfilter: &[f64; NS] = colorant.as_ref();
-    /// assert_ulps_eq!(bandfilter[548-380], 0.0);
-    /// assert_ulps_eq!(bandfilter[549-380], 1.0);
-    /// assert_ulps_eq!(bandfilter[550-380], 1.0);
-    /// assert_ulps_eq!(bandfilter[551-380], 1.0);
-    /// assert_ulps_eq!(bandfilter[552-380], 0.0);
+    /// let bandfilter = colorant.spectrum();
+    /// assert_ulps_eq!(bandfilter[548], 0.0);
+    /// assert_ulps_eq!(bandfilter[549], 1.0);
+    /// assert_ulps_eq!(bandfilter[550], 1.0);
+    /// assert_ulps_eq!(bandfilter[551], 1.0);
+    /// assert_ulps_eq!(bandfilter[552], 0.0);
     /// 
     /// ```
     pub fn top_hat(center: f64, width: f64) -> Self {
@@ -136,32 +136,7 @@ impl<F> From<F> for Colorant
 /// in the [`Observer`](crate::observer::Observer) tristiumulus `xyz`-function.
 impl Filter for Colorant {
     fn spectrum(&self) -> Cow<Spectrum> {
-        Cow::Borrowed(self)
-    }
-}
-
-impl Deref for Colorant {
-    type Target = Spectrum;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Colorant {
-
-    /// Mutable Access Spectrum methods on references of colorant.
-    ///
-    /// ```rust
-    /// use colorimetry::prelude::*;
-    /// let mut cth = Colorant::top_hat(500.0, 10.0);
-    /// cth.smooth(5.0); // use spectrum's smooth method
-    ///
-    /// let v = cth[505];
-    /// approx::assert_abs_diff_eq!(v, 0.5939434271268909);
-    /// ```
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        Cow::Borrowed(&self.0)
     }
 }
 
@@ -256,6 +231,6 @@ impl AbsDiffEq for Colorant {
     }
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        self.0.abs_diff_eq(other, epsilon)
+        self.spectrum().abs_diff_eq(&other.spectrum(), epsilon)
     }
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -255,8 +255,8 @@ pub fn gaussian_filtered_primaries(white: &Spectrum, red: [f64;3], green: [f64;2
     let [gc, gw]=  green;
     let [bc, bw]=  blue;
     [
-        Stimulus(Stimulus(Colorant::gaussian(bc, bw).mul(white)).set_luminance(&CIE1931, 100.0).0.mul_f64(f) +
-        Stimulus(Colorant::gaussian(rc, rw).mul(white)).set_luminance(&CIE1931, 100.0).0.mul_f64(1.0-f)),
+        Stimulus(Stimulus(Colorant::gaussian(bc, bw).mul(white)).set_luminance(&CIE1931, 100.0).0 * f +
+        Stimulus(Colorant::gaussian(rc, rw).mul(white)).set_luminance(&CIE1931, 100.0).0 * (1.0 - f)),
         Stimulus(Colorant::gaussian(gc, gw).mul(white)).set_luminance(&CIE1931, 100.0),
         Stimulus(Colorant::gaussian(bc, bw).mul(white)).set_luminance(&CIE1931, 100.0),
     ]

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -255,10 +255,10 @@ pub fn gaussian_filtered_primaries(white: &Spectrum, red: [f64;3], green: [f64;2
     let [gc, gw]=  green;
     let [bc, bw]=  blue;
     [
-        Stimulus(Stimulus(Colorant::gaussian(bc, bw).mul(white)).set_luminance(&CIE1931, 100.0).0 * f +
-        Stimulus(Colorant::gaussian(rc, rw).mul(white)).set_luminance(&CIE1931, 100.0).0 * (1.0 - f)),
-        Stimulus(Colorant::gaussian(gc, gw).mul(white)).set_luminance(&CIE1931, 100.0),
-        Stimulus(Colorant::gaussian(bc, bw).mul(white)).set_luminance(&CIE1931, 100.0),
+        Stimulus(Stimulus(&*Colorant::gaussian(bc, bw) * white).set_luminance(&CIE1931, 100.0).0 * f +
+        Stimulus(&*Colorant::gaussian(rc, rw) * white).set_luminance(&CIE1931, 100.0).0 * (1.0 - f)),
+        Stimulus(&*Colorant::gaussian(gc, gw) * white).set_luminance(&CIE1931, 100.0),
+        Stimulus(&*Colorant::gaussian(bc, bw) * white).set_luminance(&CIE1931, 100.0),
     ]
 }
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -255,10 +255,10 @@ pub fn gaussian_filtered_primaries(white: &Spectrum, red: [f64;3], green: [f64;2
     let [gc, gw]=  green;
     let [bc, bw]=  blue;
     [
-        Stimulus(Stimulus(&*Colorant::gaussian(bc, bw) * white).set_luminance(&CIE1931, 100.0).0 * f +
-        Stimulus(&*Colorant::gaussian(rc, rw) * white).set_luminance(&CIE1931, 100.0).0 * (1.0 - f)),
-        Stimulus(&*Colorant::gaussian(gc, gw) * white).set_luminance(&CIE1931, 100.0),
-        Stimulus(&*Colorant::gaussian(bc, bw) * white).set_luminance(&CIE1931, 100.0),
+        Stimulus(Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white).set_luminance(&CIE1931, 100.0).0 * f +
+        Stimulus(&*Colorant::gaussian(rc, rw).spectrum() * white).set_luminance(&CIE1931, 100.0).0 * (1.0 - f)),
+        Stimulus(&*Colorant::gaussian(gc, gw).spectrum() * white).set_luminance(&CIE1931, 100.0),
+        Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white).set_luminance(&CIE1931, 100.0),
     ]
 }
 

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn index_test(){
-        let mut s = Colorant::white();
+        let mut s = *Colorant::white().spectrum();
 
         // Set a spectral value
         s[500] = 0.5;
@@ -678,8 +678,8 @@ mod tests {
     #[test]
     fn add_spectra(){
         use approx::assert_ulps_eq;
-        let mut g1 = Colorant::gray(0.5);
-        let g2 = Colorant::gray(0.5);
+        let mut g1 = *Colorant::gray(0.5).spectrum();
+        let g2 = *Colorant::gray(0.5).spectrum();
         let g = g1.clone() + g2.clone();
         for i in 380..780 {
             assert_ulps_eq!(g[i], 1.0);
@@ -690,7 +690,8 @@ mod tests {
             assert_ulps_eq!(g1[i], 1.0);
         }
 
-        let v = 2.0 * *Colorant::gaussian(550.0, 50.0) + -2.0 * *Colorant::gaussian(550.0, 50.0);
+        let spectrum = *Colorant::gaussian(550.0, 50.0).spectrum();
+        let v = 2.0 * spectrum + -2.0 * spectrum;
         for i in 380..780 {
             assert_ulps_eq!(v[i], 0.0);
         }
@@ -699,7 +700,7 @@ mod tests {
     #[test]
     fn mul_spectra_test(){
         use approx::assert_ulps_eq;
-        let g = Colorant::gray(0.5);
+        let g = *Colorant::gray(0.5).spectrum();
     
         let w = 2.0 * g.clone();
         for i in 380..780 {
@@ -759,14 +760,14 @@ mod tests {
 
     #[test]
     fn test_smooth() {
-        let mut s = Colorant::default();
+        let mut s = *Colorant::default().spectrum();
         s[550] = 1.0;
         s.smooth(5.0);
 
         let sigma = sigma_from_fwhm(5.0);
         let w = Colorant::gaussian(550.0, sigma);
         let scale = sigma * (PI*2.0).sqrt(); // integral of a gaussian
-        s.0.0.iter().zip(w.0.0.iter()).enumerate().for_each(|(i, (s,w))|{
+        s.0.iter().zip(w.0.0.iter()).enumerate().for_each(|(i, (s,w))|{
             let j = i + 380;
             let w = w / scale; // change the reference gaussian colorant to have an integral of 1.0
             //println!("{j} {s:.6} {w:.6}");

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -70,11 +70,6 @@ impl Spectrum {
         self
     }
 
-    pub fn mul_f64(mut self, rhs: f64) -> Self {
-        self.0 *= rhs;
-        self
-    }
-
     /**
     This function maps spectral data with irregular intervals or intervals different than 1
     nanometer to the standard spectrum as used in this library.

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -65,11 +65,6 @@ impl Spectrum {
         Self(SVector::<f64, NS>::from_array_storage(nalgebra::ArrayStorage([data])))
     }
 
-    pub fn mul(mut self, rhs: &Self) -> Self {
-        self.0 = self.0.component_mul(&rhs.0) ;
-        self
-    }
-
     /**
     This function maps spectral data with irregular intervals or intervals different than 1
     nanometer to the standard spectrum as used in this library.


### PR DESCRIPTION
The Clippy linter pointed out that the direct `Spectrum::mul` method could be confusing for users, as it can be confused for the very common `Mul::mul` method. And `Spectrum` implements `Mul` also, and they did the same thing. So I removed both `mul` and `mul_f64` from `Spectrum` directly, recommending users to use the methods on the corresponding `Mul` implementations.

The above removal caused some errors. Previously if you had a `Colorant` value, and you called `mul` on it, it could via the `Deref<Target=Spectrum>` implementation figure out that it should defer the `Colorant` to a `Spectrum` and then call the explicit `mul` method. But it can't do this inference when the method on `Spectrum` comes from a trait. I then started looking into these `Deref` implementations and seeing if they actually made sense. [The recommendation](https://doc.rust-lang.org/stable/std/ops/trait.Deref.html#when-to-implement-deref-or-derefmut) for when and when not to implement `Deref` for a type states that:

> The same advice applies to both deref traits. In general, deref traits **should** be implemented if:
>
> 1. a value of the type transparently behaves like a value of the target type;
> 2. the implementation of the deref function is cheap; and
> 3. users of the type will not be surprised by any deref coercion behavior.
>
> In general, deref traits **should not* be implemented if:
>
> 1. the deref implementations could fail unexpectedly; or
> 2. the type has methods that are likely to collide with methods on the target type; or
> 3. committing to deref coercion as part of the public API is not desirable.

I do not think `Colorant` satisfies "a value of the type transparently behaves like a value of the target type". Since the `Colorant` has its values clamped in the range 0.0 - 1.0, it does not behave exactly like a `Spectrum`. Also similarly "users of the type will not be surprised by any deref coercion behavior." and "the type has methods that are likely to collide with methods on the target type; or" rule out implementing `Deref` IMO. Because traits such as `Mul` and `Add` are implemented on **both** `Colorant` and `Spectrum`. So if one can have automatic dereference to the other, how can the user know which implementation is called? They also behave differently, since one of them clamp the values and the other does not.

I think it would be much clearer and cleaner if the user have to explicitly fetch the underlying spectrum via the `Light::spectrum` method, if they want to work on spectrums instead of colorants. Explicit is better than implicit.

How strict is the requirement that a `Colorant` stays in the range 0.0 - 1.0? Currently there is not much documentation on this type. But I got the impression that it should be a spectrum where all values stay in 0.0 - 1.0. If it's just a "recommendation" that they stay within this range, then the purpose of the type becomes a bit muddy IMHO. So I went ahead and made this clamping much stricter. First of all the `DerefMut<Target=Spectrum>` had to go, since we can't allow a user to freely modify the underlying spectrum when there are requirements on the spectrum content. I also made more modifying methods apply the clamping.