### PR TITLE
Add helpful constructors to `Illuminant` and `Colorant`

### DIFF
--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -6,10 +6,28 @@ use nalgebra::SVector;
 use crate::{physics::{gaussian_peak_one, wavelength}, spectrum::wavelengths, error::CmtError, traits::Filter, spectrum::{Spectrum, NS}};
 
 
+/// A Colorant represents color filters and color patches. These are spectrums
+/// with spectral values between 0.0 and 1.0.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Colorant(pub(crate) Spectrum);
 
 impl Colorant {
+    /// Creates a Colorant from a spectrum, while validating the spectrum values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the spectrum contains values outside the range 0.0 to 1.0.
+    pub fn new(spectrum: Spectrum) -> Result<Self, CmtError> {
+        if spectrum.values().iter().any(|v| !(0.0..=1.0).contains(v)) {
+            Err(CmtError::OutOfRange {
+                name: "Colorant Spectral Value".into(),
+                low: 0.0,
+                high: 1.0,
+            })
+        } else {
+            Ok(Self(spectrum))
+        }
+    }
 
     /// Theoretical spectrum of a perfect grey colorant, consisting of 401
     /// values equal to the value given in the argument, over a range from 380
@@ -84,20 +102,16 @@ impl Colorant {
 
 }
 
-/// Create a Colorant Spectrum from a data slice, with data check.
-/// 
-/// In this library, the Colorant category represents color filters and color patches, with have spectral values between 0.0 and 1.0.
-/// This is the preferred way to crete a colorant, as it does a range check.
-impl TryFrom<&[f64]> for Colorant {
+impl TryFrom<Spectrum> for Colorant {
     type Error = CmtError;
 
-    fn try_from(data: &[f64]) -> Result<Self, Self::Error> {
-        if data.iter().any(|v| !(0.0..=1.0).contains(v)){
-            Err(CmtError::OutOfRange { name: "Colorant Spectral Value".into(), low: 0.0, high: 1.0 })
-        } else {
-            let spectrum = Spectrum::try_from(data)?;
-            Ok(Self(spectrum))
-        }
+    /// Creates a Colorant from a spectrum, while validating the spectrum values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the spectrum contains values outside the range 0.0 to 1.0.
+    fn try_from(spectrum: Spectrum) -> Result<Self, Self::Error> {
+        Self::new(spectrum)
     }
 }
 

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -25,6 +25,10 @@ impl Deref for Illuminant{
 
 
 impl Illuminant {
+    /// Creates an illuminant directly from a spectrum.
+    pub fn new(spectrum: Spectrum) -> Self {
+        Illuminant(spectrum)
+    }
 
     /// E, or Equal Energy Illuminant with an irradiance of 1 Watt per square
     /// meter in the spectrum between 380 and 780 nanometer
@@ -158,11 +162,10 @@ impl Illuminant {
     }
 }
 
-impl TryFrom<&[f64]> for Illuminant {
-    type Error = CmtError;
-
-    fn try_from(value: &[f64]) -> Result<Self, Self::Error> {
-        Ok(Illuminant(value.try_into()?))
+/// Creates an illuminant directly from a spectrum.
+impl From<Spectrum> for Illuminant {
+    fn from(spectrum: Spectrum) -> Self {
+        Self::new(spectrum)
     }
 }
 

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -157,6 +157,13 @@ impl Spectrum {
         let t = self.0.convolve_full(kernel);
         self.0 = SVector::from_iterator(t.iter().copied().skip(sd3 as usize).take(NS));
     }
+
+    /// Returns the spectral data values, as an array of floats.
+    ///
+    /// The array contains the 401 data points from 380 to 780 nanometer.
+    pub fn values(&self) -> &[f64; NS] {
+        &self.0.data.0[0]
+    }
 }
 
 impl From<[f64; NS]> for Spectrum {
@@ -185,7 +192,7 @@ impl Default for Spectrum {
 
 impl AsRef<[f64;401]> for Spectrum {
     fn as_ref(&self) -> &[f64;401] {
-        &self.0.data.0[0]
+        self.values()
     }
 }
 


### PR DESCRIPTION
Both `Illuminant` and `Colorant` are just wrappers around a `Spectrum`, with some special meaning (and sometimes constraints on the spectral values). However, there was no simple way to create these types from spectrums. Both types had `TryFrom<&[f64]>`, but this has a number of problems IMHO:
1. It's hard to find the `From`/`TryFrom` implementations in the documentation as they are mixed up with loads of trait implementations.
2. It performs conversions in multiple steps at once: `slice of unknown length` -> `array of known length` -> `Spectrum` -> `Illuminant/Colorant`. This makes it impossible to go directly from a `Spectrum` to an `Illuminant/Colorant`. This is both a problem in terms of paying for data validation when you might already know you have the correct data, and it's harder for the user to know what goes on when there are multiple "hidden" conversion steps.

As obvious from #16, I was not even able to spot how to create `Illuminant`s at all :upside_down_face:.

I'd recommend to always expose the most direct and obvious constructors as the first methods directly on the type. And to always provide the most direct `From`/`TryFrom` implementations between types. And only expose constructor/conversion implementations that perform multiple steps of conversions if they will be very frequently used, so that not having them would be cumbersome for the average user.

In this PR I choose to remove the `TryFrom<&[64]>` implementations, since a library user can easily get that behavior by being a bit more explicit anyway: `Illuminant::new(Spectrum::try_from(my_slice))`