### PR TITLE
Fix documentation link, causing CI failure

### DIFF
--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -172,7 +172,7 @@ impl<F> From<F> for Colorant
 
 
 /// Make colorant data available as a generic [`Filter`] entity, used in particular
-/// in the [`Observer`](crate::observer::Observer) tristiumulus `xyz`-function.
+/// in the [`Observer`] tristiumulus `xyz`-function.
 impl Filter for Colorant {
     fn spectrum(&self) -> Cow<Spectrum> {
         Cow::Borrowed(&self.0)


### PR DESCRIPTION
Commit dd59b7f91d8de2cea64e0517c89d1ea688583d7d introduced a warning in the documentation generation. The CI became angry: https://github.com/harbik/colorimetry/actions/runs/14685003615/job/41212481440

This PR simply fixes that. To make it clean and passing again.