### PR TITLE
Adding a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All noteworthy changes to the library should be noted here.
+
+### Format
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+Entries should have the imperative form, just like commit messages. Start each entry with words like
+add, fix, increase, force etc.. Not added, fixed, increased, forced etc.
+
+Line wrap the file at 100 chars.                                              That is over here -> |
+
+### Categories each change fall into
+
+* **Added**: for new features.
+* **Changed**: for changes in existing functionality.
+* **Deprecated**: for soon-to-be removed features.
+* **Removed**: for now removed features.
+* **Fixed**: for any bug fixes.
+* **Security**: in case of vulnerabilities.
+
+
+## [Unreleased]
+### Added
+- Add `RGB::values()` method for easy access to the raw red, green and blue values.
+- Enable all features when building documentation for docs.rs.
+- Add `Spectrum::values() -> &[f64; 401]` for direct access to the underlying spectral data.
+- Add `Illuminant::new(Spectrum)` and `From<Spectrum> for Illuminant` for easy creation of
+  custom illuminants from spectral data.
+- Add `Colorant::new(Spectrum)` and `TryFrom<Spectrum> for Colorant` for easy creation of
+  custom colorants from spectral data.
+- Add `Illuminant::xyz` to compute XYZ tristimulus values directly from an illuminant.
+  convenience shorthand for calling `xyz_from_spectrum` on the observer.
+- Add `Colorant::cielab` method for calculating the CIELAB values of a colorant, given an
+  illuminant and an observer.
+
+### Changed
+- Take fixed size arrays instead of slices in `XYZ::new`. Makes the function signature clearer,
+  and removes a possible panic case.
+
+### Removed
+- Remove the `paste` and `url` dependencies, since they were unused. And move the
+  `colored` dependency to `dev-dependencies` since it was only used in examples.
+- Remove `mul` and `mul_f64` methods from `Spectrum`. Multiplication can still be done via the
+  `Mul<Spectrum>` and `Mul<f64>` trait implementations.
+- Remove `Deref` and `DerefMut` implementations on `Colorant` that allowed dereference to
+  `Spectrum`s. The underlying spectrum can still be obtained via the `Filter::spectrum` method.
+- Remove `TryFrom<&[f64]> for Illuminant`. Instead use `Illuminant::new(Spectrum::try_from(slice))`
+  or the infallible `From<Spectrum> for Illuminant` if you already have a spectrum.
+- Remove `TryFrom<&[f64]> for Colorant`
+
+### Fixed
+- Ensure the spectral values of a `Colorant` stays within the range 0.0 - 1.0. It was previously
+  possible to move outside the allowed range due to the `DerefMut<Target=Spectrum>` implementation,
+  and some missing clamping in other arithmetic operations on the colorant.
+
+
+## [0.0.3] - 2025-04-16
+
+
+## [0.0.2] - 2024-08-09
+
+
+## [0.0.1] - 2024-08-09


### PR DESCRIPTION
It would be great to cut a new release rather soon. A ton of improvements have happened since `0.0.3` was released! But the more releases there are, and the more the API changes, the more important it becomes to have a changelog. This helps library users a lot when upgrading their dependencies.

I copied the format I usually use for Rust crates. keepachangelog.com is an established standard, so it's nice to stick to something someone else thought through IMHO.

I listed the dates for all the previous releases. But I did not make the effort to list all their changes. That can be added later if someone feel it's important. For me it's more important to document changes from now and going forward :)