### PR TITLE
Relax chromaticity value verification in `try_from_chromaticity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Line wrap the file at 100 chars.                                              Th
 - Ensure the spectral values of a `Colorant` stays within the range 0.0 - 1.0. It was previously
   possible to move outside the allowed range due to the `DerefMut<Target=Spectrum>` implementation,
   and some missing clamping in other arithmetic operations on the colorant.
+- Relax bounds checking in `XYZ::try_from_chromaticity` to allow the sum of `x` and `y` to be
+  exactly `1.0` instead of just strictly smaller.
 
 
 ## [0.0.3] - 2025-04-16

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -75,7 +75,7 @@ impl XYZ {
     ) -> Result<XYZ, CmtError> {
         let l = l.unwrap_or(100.0);
         let observer = observer.unwrap_or_default();
-        if (x + y) >= 1.0 {
+        if (x + y) > 1.0 {
             Err(CmtError::InvalidChromaticityValues)
         } else {
             let s = l / y;


### PR DESCRIPTION
I'm not sure if this change is sound. So maybe regard this as question primarily, and a change suggestion secondarily :)

The following code shows the problem:
```rust
use colorimetry::prelude::*;

fn main() {
    let observer = Observer::Std1931;
    let nm_min = observer.data().spectral_locus_nm_min();
    let nm_max = observer.data().spectral_locus_nm_max();
    for nm in nm_min..=nm_max {
        let xyz_in = observer.data().spectral_locus_by_nm(nm).unwrap();
        let [x, y] = xyz_in.chromaticity();

        let xyz_out = XYZ::try_from_chromaticity(x, y, None, Some(observer)).expect("Oh no!");
    }
}
```
This code panics with:
```
thread 'main' panicked at examples/spectral_locus.rs:11:78:
Oh no!: InvalidChromaticityValues
```

For some XYZ values along the spectral locus, the sum of the chromaticity coordinates is exactly 1.0. This cause the `try_from_chromaticity` method to return an error. Is it correct that the sum of chromaticity coordinates must be _strictly less than_ 1.0, or is equal to 1.0 also fine? Maybe it is correct that it should be less than 1.0, and the code is already correct, but rounding errors give me this problem? Or can we relax the validity check slightly here to make it possible to convert from XYZ -> chromaticity -> XYZ again without errors?