### PR TITLE
Remove the `CmtError` variants that are never used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove `TryFrom<&[f64]> for Illuminant`. Instead use `Illuminant::new(Spectrum::try_from(slice))`
   or the infallible `From<Spectrum> for Illuminant` if you already have a spectrum.
 - Remove `TryFrom<&[f64]> for Colorant`
+- Remove all error variants in `CmtError` that were unused.
 
 ### Fixed
 - Ensure the spectral values of a `Colorant` stays within the range 0.0 - 1.0. It was previously

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,22 +2,8 @@ use wasm_bindgen::JsValue;
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum CmtError {
-    #[error("please provide {0} arguments only")]
-    ProvideOnlyArguments(String),
-    #[error("please provide a single {0} argument only")]
-    ProvideArgumentOnly(String),
     #[error("{name} should be within in range from {low} to {high}")]
     OutOfRange { name: String, low: f64, high: f64 },
-    #[error("Currently only support for 3 primaries")]
-    ThreePrimariesOnly,
-    #[error("Out of Gamut")]
-    OutOfGamut,
-    #[error("Not yet implemented")]
-    NotYetImplemented,
-    #[error("Provide at least one {0} argument")]
-    AtLeastOne(String),
-    #[error("CCT Robertson Slope Error")]
-    CCTRobertsonSlopeError,
     #[error("Error: {0}")]
     ErrorString(String),
     #[error("CCT: Distance to Planck locus >0.05")]
@@ -28,34 +14,6 @@ pub enum CmtError {
     CCTTemperatureTooHigh,
     #[error("CCT: Temperature too low")]
     CCTTemperatureTooLow,
-    #[error("CCT: Maximum evaluation depth for CCT calculation in this implementation is {0}")]
-    CCTEvaluationDept(u32),
-    #[error("MacAdam: Point outside triangle, no interpolation possible")]
-    MacAdamInterpolateError,
-    #[error("RGB Display: Out of gamut")]
-    RgbDisplayOutOfGamutError,
-    #[error("CRI: No illuminant, use 'illuminant(light)' first")]
-    CriNoSourceError,
-    #[error("Colorant: No match found")]
-    ColorantNoMatch,
-    #[error("Primaries: Same White Point needed for RGB-transform between Observers")]
-    PrimariesRgbTransformWhiteMismatch,
-    #[error("Color Matching Function {0} not found")]
-    ColorMatchingFunctionNotfound(String),
-    #[error("Please provide the primaries in red, green, and blue order")]
-    RgbTransformNotInRgbOrder,
-    #[error("White point seems to be out of gamut")]
-    NoWhiteBalance,
-    #[error("Could not invert the RGB Matrix")]
-    CouldNotInvertRGBMatrix,
-    #[error("RgbTransforms: Please provide exactly three primaries only")]
-    ProvideThreePrimariesOnly,
-    #[error("RgbDisplay: Provide Observer Names only")]
-    ProvideObserverNamesOnly,
-    #[error("RgbDisplay: Provide Observer Names only")]
-    ProvideOnlyTwoObservers,
-    #[error("BoxcarIntegrator: please decrease domain resolution")]
-    DomainStepError,
     #[error("Data size Error: need exactly 401 data values")]
     DataSize401Error,
     #[error("Linear Interpolate: Incorrect wavelength data")]


### PR DESCRIPTION
I found that a decent amount of the large collection of error cases sits unused. I'm guessing that these are historical remains from previous iterations of the code, but I did not look too much in the git history :)

I figured we better clean these up. If they are needed for some yet-to-be-written functionality, they can be added back once that functionality is in place IMHO.