### PR TITLE
Simplify internal `OnceLock` caching and fix a clippy warning

### DIFF
--- a/src/cct.rs
+++ b/src/cct.rs
@@ -259,14 +259,10 @@ fn iso_temp_line(t: f64) -> [f64; 3] {
 /// For more information, see `The Improved Robertson Method for Calculating
 /// Correlated Color Temperature` by Gerard Harbers.
 pub fn robertson_table(im: usize) -> &'static [f64; 3] {
-    static ROBERTSON_TABLE: OnceLock<[OnceLock<[f64; 3]>; N_STEPS]> = OnceLock::new();
-
-    // Get reference to table, or initialize it when not done yet.
-    const UVM_EMPTY: OnceLock<[f64; 3]> = OnceLock::new();
-    let robertson_table = ROBERTSON_TABLE.get_or_init(|| [UVM_EMPTY; N_STEPS]);
+    static ROBERTSON_TABLE: [OnceLock<[f64; 3]>; N_STEPS] = [const { OnceLock::new() }; N_STEPS];
 
     // Get table row, or calculate when not done yet.
-    robertson_table[im].get_or_init(|| {
+    ROBERTSON_TABLE[im].get_or_init(|| {
         let cct = im2t(im);
         iso_temp_line(cct)
     })


### PR DESCRIPTION
Clippy was giving off a bunch of these warnings:
```
warning: a `const` item should not be interior mutable
   --> src/cct.rs:265:5
    |
265 |     const UVM_EMPTY: OnceLock<[f64; 3]> = OnceLock::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider making this a static item
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const
    = note: `#[warn(clippy::declare_interior_mutable_const)]` on by default
```

See the [link in the warning](https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const) on why it's dangerous to put types providing interior mutability in `const`s. These could not be made `static`, since they do need to *copied* to every element in their respective arrays. But we can achieve the same results with `const { OnceLock::new() }` and avoid the "risk" pointed out by `clippy::declare_interior_mutable_const`. Here I put "risk" in quotes, because there is no problem with the current usage of the `EMPTY` consts really.

I also simplify a bunch of `OnceLock<[OnceLock<...>; N]>` types to just [OnceLock<...>; N]. I could not see any reason why the array needed lazy thread safe initialization. This new way just instantiates all `OnceLock`s directly into the array instead.

# Having caching at all?

I can't say I'm a big fan of all the internal caching that `colorimetry` does. I don't know how you use the library, so maybe this makes a lot of sense for your use case. But I think this behavior would be best implemented on a higher level by a user who repeatedly calls the expensive computations. Currently the caching costs a noticeable amount of complexity. It also relies on all these array length constants that are hardcoded (`const XYZ_STD_ILLUMINANTS_LEN: usize = 64;` etc.). These are values that must be updated if the number of variants it can cache changes, but that can be easily forgotten, introducing bugs. So it's a bit of a code smell IMHO.

If I were to use write a program that uses the "RGB to XYZ" matrix for example, I would call the library once to generate the matrix, then just store it in a local variable/struct field in my code, instead of calling into `colorimetry` every time I needed the matrix. That would probably be simpler code to read, and it would be more performant. Needing a thread safe initialization check on a `OnceLock` for every usage of the `Matrix` would be way more costly than just storing it locally. This sort of defeats the purpose of the caching?