### PR TITLE
Replace public static `XY_PRIMARIES` with methods on space enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Take fixed size arrays instead of slices in `XYZ::new`. Makes the function signature clearer,
   and removes a possible panic case.
+- Replace the public global static `XY_PRIMARIES` with the methods `name`,
+  `primaries_chromaticity` and `white` on the `RgbSpace` type.
 
 ### Removed
 - Remove the `paste` and `url` dependencies, since they were unused. And move the

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -433,7 +433,7 @@ impl ObserverData {
             [const { OnceLock::new() }; RGB2XYZ_AR_LEN];
 
         RGB2XYZ_AR[*rgbspace as usize].get_or_init(|| {
-            let (space, _) = rgbspace.data();
+            let space = rgbspace.data();
             let mut rgb2xyz = Matrix3::from_iterator(space.primaries.iter().flat_map(|s| {
                 self.xyz_from_spectrum(s, None)
                     .set_illuminance(1.0)

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -73,7 +73,7 @@ impl RGB {
         let space = space.unwrap_or_default();
         let [r, g, b] = [r_u8, g_u8, b_u8]
             .map(|v| (v as f64 / 255.0).clamp(0.0, 1.0))
-            .map(|v| space.data().0.gamma.decode(v));
+            .map(|v| space.data().gamma.decode(v));
         RGB::new(r, g, b, observer, Some(space))
     }
 
@@ -91,7 +91,7 @@ impl RGB {
         let space = space.unwrap_or_default();
         let [r, g, b] = [r_u16, g_u16, b_u16]
             .map(|v| (v as f64 / 65_535.0).clamp(0.0, 1.0))
-            .map(|v| space.data().0.gamma.decode(v));
+            .map(|v| space.data().gamma.decode(v));
         RGB::new(r, g, b, observer, Some(space))
     }
 
@@ -120,7 +120,7 @@ impl RGB {
         let xyzn = self
             .observer
             .data()
-            .xyz(&self.space.data().0.white, None)
+            .xyz(&self.space.data().white, None)
             .set_illuminance(100.0)
             .xyzn;
         let xyz = self.observer.data().rgb2xyz(&self.space) * self.rgb;
@@ -190,7 +190,7 @@ mod rgb_tests {
 
 impl Light for RGB {
     fn spectrum(&self) -> Cow<Spectrum> {
-        let prim = &self.space.data().0.primaries;
+        let prim = &self.space.data().primaries;
         let yrgb = self.observer.data().rgb2xyz(&self.space).row(1);
         //        self.rgb.iter().zip(yrgb.iter()).zip(prim.iter()).map(|((v,w),s)|*v * *w * &s.0).sum()
         let s = self
@@ -221,7 +221,7 @@ impl Filter for RGB {
         ```
     */
     fn spectrum(&self) -> Cow<Spectrum> {
-        let prim = self.space.data().0.primaries_as_colorants();
+        let prim = self.space.data().primaries_as_colorants();
         let yrgb = self.observer.data().rgb2xyz(&self.space).row(1);
         let s = self
             .rgb
@@ -243,7 +243,7 @@ impl AsRef<Vector3<f64>> for RGB {
 impl From<RGB> for [u8; 3] {
     fn from(rgb: RGB) -> Self {
         let data: &[f64; 3] = rgb.rgb.as_ref();
-        data.map(|v| (rgb.space.data().0.gamma.encode(v.clamp(0.0, 1.0)) * 255.0).round() as u8)
+        data.map(|v| (rgb.space.data().gamma.encode(v.clamp(0.0, 1.0)) * 255.0).round() as u8)
     }
 }
 

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -73,7 +73,7 @@ impl Sum for Stimulus {
 /// not only the CIE 1931 standard observer.
 impl From<RGB> for Stimulus {
     fn from(rgb: RGB) -> Self {
-        let prim = &rgb.space.data().0.primaries;
+        let prim = &rgb.space.data().primaries;
         let yrgb = rgb.observer.data().rgb2xyz(&rgb.space).row(1);
         rgb.rgb
             .iter()


### PR DESCRIPTION
Clippy warned that `LazyLock<HashMap<&str, ([[f64; 2]; 3], StdIlluminant)>>` was a very complex type and should be considered for refactoring or being made into a type alias. So I looked closer at the `XY_PRIMARIES` code. I came to the conclusion that these values are probably better exposed as dedicated methods on the existing `RgbSpace` type. This allows us to get rid of both the lock and the heap allocated map.

Where one would previously write `XY_PRIMARIES.keys()` one can now instead use `RgbSpace::iter()` along with the new methods `name`, `primaries_chromaticity` and `white` to obtain the same information. This ties the data closer to the `RgbSpace` type, instead of being a standalone static.

Having dedicated methods for each type of data, instead of returning tuples, allows writing a lot less `.0` and `.1` after function calls. This improves readability IMHO.