### PR TITLE
Fix remaining clippy warnings and add clippy to CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,24 @@
+---
+name: Rust linting
+on:
+  pull_request:
+    paths:
+      - .github/workflows/*.yml
+      - '**/*.rs'
+
+  workflow_dispatch:
+jobs:
+  clippy-linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install latest stable Rust
+        run: rustup update stable
+
+      - name: Clippy check
+        env:
+          RUSTFLAGS: --deny warnings
+        run: |
+          cargo clippy --locked --all-targets --no-default-features
+          cargo clippy --locked --all-targets --all-features

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -154,60 +154,6 @@ impl AsRef<[f64]> for CRI {
 #[wasm_bindgen]
 impl CRI {}
 
-#[cfg(test)]
-mod cri_test {
-    use crate::prelude::*;
-
-    #[test]
-    fn cri_d50() {
-        // should be all 100.0
-        let cri0: CRI = (&D50).try_into().unwrap();
-        // println!("{cri0:?}");
-        approx::assert_ulps_eq!(
-            cri0.as_ref(),
-            [100.0; crate::cri::N_TCS].as_ref(),
-            epsilon = 0.03
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "cie-illuminants")]
-    fn cri_f1() {
-        // should be all 100.0
-        let cri0: CRI = StdIlluminant::F1.illuminant().try_into().unwrap();
-        println!("{cri0:?}");
-        // approx::assert_ulps_eq!(cri0.as_ref(), [100.0;crate::cri::N_TCS].as_ref(), epsilon = 0.05);
-    }
-
-    #[test]
-    #[cfg(feature = "cie-illuminants")]
-    fn cri_f3_1() {
-        // 2932K, check with values as given in CIE15:2004 Table T.8.2
-        let cri0: CRI = StdIlluminant::F3_1.illuminant().try_into().unwrap();
-        approx::assert_ulps_eq!(
-            cri0.as_ref(),
-            [42, 69, 89, 39, 41, 52, 66, 13, -109, 29, 19, 21, 47, 93]
-                .map(|v| v as f64)
-                .as_ref(),
-            epsilon = 1.0
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "cie-illuminants")]
-    fn cri_f3_11() {
-        // 5854K, check with values as given in CIE15:2004 Table T.8.2
-        let cri0: CRI = StdIlluminant::F3_11.illuminant().try_into().unwrap();
-        approx::assert_ulps_eq!(
-            cri0.as_ref(),
-            [90, 86, 49, 82, 81, 70, 85, 79, 24, 34, 64, 50, 90, 67]
-                .map(|v| v as f64)
-                .as_ref(),
-            epsilon = 1.0
-        );
-    }
-}
-
 fn cd(uv60: [f64; 2]) -> [f64; 2] {
     let [u, v] = uv60;
     [
@@ -362,3 +308,57 @@ static TCS5: SMatrix<f64, 81, N_TCS> = SMatrix::from_array_storage(ArrayStorage(
         0.379, 0.39, 0.399,
     ],
 ]));
+
+#[cfg(test)]
+mod cri_test {
+    use crate::prelude::*;
+
+    #[test]
+    fn cri_d50() {
+        // should be all 100.0
+        let cri0: CRI = (&D50).try_into().unwrap();
+        // println!("{cri0:?}");
+        approx::assert_ulps_eq!(
+            cri0.as_ref(),
+            [100.0; crate::cri::N_TCS].as_ref(),
+            epsilon = 0.03
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cie-illuminants")]
+    fn cri_f1() {
+        // should be all 100.0
+        let cri0: CRI = StdIlluminant::F1.illuminant().try_into().unwrap();
+        println!("{cri0:?}");
+        // approx::assert_ulps_eq!(cri0.as_ref(), [100.0;crate::cri::N_TCS].as_ref(), epsilon = 0.05);
+    }
+
+    #[test]
+    #[cfg(feature = "cie-illuminants")]
+    fn cri_f3_1() {
+        // 2932K, check with values as given in CIE15:2004 Table T.8.2
+        let cri0: CRI = StdIlluminant::F3_1.illuminant().try_into().unwrap();
+        approx::assert_ulps_eq!(
+            cri0.as_ref(),
+            [42, 69, 89, 39, 41, 52, 66, 13, -109, 29, 19, 21, 47, 93]
+                .map(|v| v as f64)
+                .as_ref(),
+            epsilon = 1.0
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cie-illuminants")]
+    fn cri_f3_11() {
+        // 5854K, check with values as given in CIE15:2004 Table T.8.2
+        let cri0: CRI = StdIlluminant::F3_11.illuminant().try_into().unwrap();
+        approx::assert_ulps_eq!(
+            cri0.as_ref(),
+            [90, 86, 49, 82, 81, 70, 85, 79, 24, 34, 64, 50, 90, 67]
+                .map(|v| v as f64)
+                .as_ref(),
+            epsilon = 1.0
+        );
+    }
+}

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -331,7 +331,7 @@ fn test_d_illuminant_range_error() {
 #[test]
 fn test_xyz() {
     use crate::prelude::*;
-    let s = Illuminant::d_illuminant(6504.0).unwrap().values().clone();
+    let s = *Illuminant::d_illuminant(6504.0).unwrap().values();
     let illuminant = Illuminant(Spectrum::from(s));
     let xyz = illuminant.xyz(None).set_illuminance(100.0);
     approx::assert_ulps_eq!(xyz, CIE1931.xyz_d65(), epsilon = 2E-2);

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -31,12 +31,12 @@ use crate::cri::CRI;
 /// a spectrometer. In this library, spectral values span a wavelength range from 380 to 780
 /// nanometers, including the end points, with a step size of 1 nanometer, resulting in 401 spectral
 /// values.
-
+///
 /// Creating a new illuminant can be done by using the `Illuminant::new` method, which takes a
 /// `Spectrum` as input. Alternatively, you can use the provided static methods to create common
 /// illuminants, such as `Illuminant::d65()` for the D65 standard illuminant, or `Illuminant::planckian(3000.0)`
 /// for a Planckian illuminant at 3000 Kelvin.
-
+///
 /// The `Illuminant` struct provides methods to manipulate the spectral values, such as
 /// `set_irradiance` to set the total irradiance of the illuminant, and `set_illuminance` to set the
 /// illuminance in lux. It also provides methods to calculate irradiance, illuminance, and the

--- a/src/munsell_matt.rs
+++ b/src/munsell_matt.rs
@@ -102,6 +102,17 @@ impl Filter for MunsellMatt {
     }
 }
 
+pub static MM_KEY_MAP: LazyLock<BTreeMap<&str, usize>> = LazyLock::new(|| {
+    let mut map = BTreeMap::new();
+    MUNSELL_MATT_KEYS
+        .iter()
+        .enumerate()
+        .for_each(|(value, &key)| {
+            map.insert(key, value);
+        });
+    map
+});
+
 #[cfg(test)]
 mod test_munsell_matt {
     use crate::prelude::*;
@@ -119,14 +130,3 @@ mod test_munsell_matt {
         assert_eq!(mm.0, "10RP4/12".to_string());
     }
 }
-
-pub static MM_KEY_MAP: LazyLock<BTreeMap<&str, usize>> = LazyLock::new(|| {
-    let mut map = BTreeMap::new();
-    MUNSELL_MATT_KEYS
-        .iter()
-        .enumerate()
-        .for_each(|(value, &key)| {
-            map.insert(key, value);
-        });
-    map
-});

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -165,29 +165,6 @@ impl RGB {
      */
 }
 
-#[cfg(test)]
-mod rgb_tests {
-    use crate::prelude::*;
-
-    #[test]
-    fn get_values_f64() {
-        let rgb = RGB::new(0.1, 0.2, 0.3, None, None);
-        let [r, g, b] = <[f64; 3]>::from(rgb);
-        assert_eq!(r, 0.1);
-        assert_eq!(g, 0.2);
-        assert_eq!(b, 0.3);
-    }
-
-    #[test]
-    fn get_values_u8() {
-        let rgb = RGB::new(0.1, 0.2, 0.3, None, None);
-        let [r, g, b] = <[u8; 3]>::from(rgb);
-        assert_eq!(r, 89);
-        assert_eq!(g, 124);
-        assert_eq!(b, 149);
-    }
-}
-
 impl Light for RGB {
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = &self.space.data().primaries;
@@ -298,4 +275,27 @@ pub fn gaussian_filtered_primaries(
         Stimulus(&*Colorant::gaussian(gc, gw).spectrum() * white).set_luminance(&CIE1931, 100.0),
         Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white).set_luminance(&CIE1931, 100.0),
     ]
+}
+
+#[cfg(test)]
+mod rgb_tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn get_values_f64() {
+        let rgb = RGB::new(0.1, 0.2, 0.3, None, None);
+        let [r, g, b] = <[f64; 3]>::from(rgb);
+        assert_eq!(r, 0.1);
+        assert_eq!(g, 0.2);
+        assert_eq!(b, 0.3);
+    }
+
+    #[test]
+    fn get_values_u8() {
+        let rgb = RGB::new(0.1, 0.2, 0.3, None, None);
+        let [r, g, b] = <[u8; 3]>::from(rgb);
+        assert_eq!(r, 89);
+        assert_eq!(g, 124);
+        assert_eq!(b, 149);
+    }
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -131,28 +131,28 @@ impl RGB {
         }
     }
 
-    /// Creates a callback of closure function, which takes a set or RGB values, within a color
-    /// space and viewed as one observer, and returns a new set of RGB values, represeting the
-    /// stimulus in another color space, and using another observer.
-    ///
-    /// This conversion uses the spectral represenations of the primaries through the color space
-    /// `Spectra` function, to create a  transformation matrix.
-    pub fn convert(
-        obs_from: Observer,
-        space_from: RgbSpace,
-        obs: Observer,
-        space: RgbSpace,
-    ) -> Box<dyn Fn(&Vector3<f64>) -> Vector3<f64>> {
-        todo!()
-    }
+    // /// Creates a callback of closure function, which takes a set or RGB values, within a color
+    // /// space and viewed as one observer, and returns a new set of RGB values, represeting the
+    // /// stimulus in another color space, and using another observer.
+    // ///
+    // /// This conversion uses the spectral represenations of the primaries through the color space
+    // /// `Spectra` function, to create a  transformation matrix.
+    // pub fn convert(
+    //     obs_from: Observer,
+    //     space_from: RgbSpace,
+    //     obs: Observer,
+    //     space: RgbSpace,
+    // ) -> Box<dyn Fn(&Vector3<f64>) -> Vector3<f64>> {
+    //     todo!()
+    // }
 
-    /// Transform a set of RGB values, defining a stimulus for one standard observer, into a set of
-    /// RGB values representing the same stimulus for different standard observer or special
-    /// observer.  On initial use this function calculates a transformation matrix based on the
-    /// colorimetric tristimulus values of the respective primaries.
-    pub fn transform(&self, obs_from: &Observer) -> Self {
-        todo!()
-    }
+    // /// Transform a set of RGB values, defining a stimulus for one standard observer, into a set of
+    // /// RGB values representing the same stimulus for different standard observer or special
+    // /// observer.  On initial use this function calculates a transformation matrix based on the
+    // /// colorimetric tristimulus values of the respective primaries.
+    // pub fn transform(&self, obs_from: &Observer) -> Self {
+    //     todo!()
+    // }
 
     /*
     /// Creates a [Spectrum] from an [RGB] value, using the spectral primaries of its color space.

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -732,7 +732,7 @@ mod tests {
         use approx::assert_ulps_eq;
         let mut g1 = *Colorant::gray(0.5).spectrum();
         let g2 = *Colorant::gray(0.5).spectrum();
-        let g = g1.clone() + g2.clone();
+        let g = g1 + g2;
         for i in 380..780 {
             assert_ulps_eq!(g[i], 1.0);
         }
@@ -753,7 +753,7 @@ mod tests {
         use approx::assert_ulps_eq;
         let g = *Colorant::gray(0.5).spectrum();
 
-        let w = 2.0 * g.clone();
+        let w = 2.0 * g;
         for i in 380..780 {
             assert_ulps_eq!(w[i], 1.0);
         }


### PR DESCRIPTION
This PR fixes all remaining warnings that clippy emit with its default config. But this PR also depends on #26 and #25, since they also fix clippy warnings. So this CI will fail until those other two are merged and this is rebased on top latest `main` again.

Since all clippy will be fixed if all these three PRs are merged, I went ahead and added clippy to the CI. This allows catching code smells and other problems before they are merged.