### PR TITLE
Fix bug in `RgbSpaceData::primaries_as_colorants` by removing caching

### DIFF
--- a/src/rgbspace.rs
+++ b/src/rgbspace.rs
@@ -124,22 +124,22 @@ impl RgbSpaceData {
     /**
      Get primaries as colorants.
 
-     Buffered - calculated on first use by division with the referene white illuminant.
-     Reference white spectra should not have 0.0 values.
+     This is the primaries stimulus divided by the reference white.
+
+     # Panics
+
+     If the RGB space reference white has 0.0 values in it, then this cause a division by zero.
     */
-    pub fn primaries_as_colorants(&self) -> &[Colorant; 3] {
-        static PRIMARY_FILTERS: OnceLock<[Colorant; 3]> = OnceLock::new();
-        PRIMARY_FILTERS.get_or_init(|| {
-            let white = self
-                .white
-                .illuminant()
-                .clone()
-                .set_illuminance(&CIE1931, 100.0)
-                .0;
-            // RGB primaries defined with reference to CIE1931, and 100 cd/m2.
-            let sa = self.primaries.each_ref().map(|v| &v.0 / &white);
-            sa.map(Colorant)
-        })
+    pub fn primaries_as_colorants(&self) -> [Colorant; 3] {
+        let white = self
+            .white
+            .illuminant()
+            .clone()
+            .set_illuminance(&CIE1931, 100.0)
+            .0;
+        // RGB primaries defined with reference to CIE1931, and 100 cd/m2.
+        let sa = self.primaries.each_ref().map(|v| &v.0 / &white);
+        sa.map(Colorant)
     }
 
     /**


### PR DESCRIPTION
The single static `OnceLock` was shared between all instances of RgbSpaceData. As a result, every invocation of primaries_as_colorants always returned the same value (the colorants of the first call to this method). The closure passed to `PRIMARY_FILTERS.get_or_init(|| ...)` is only called the first time `primaries_as_colorants` is called, and then the same value is returned on subsequent calls.

Consider this example code:
```rust
use colorimetry::prelude::RgbSpaceData;

fn main() {
    let srgb_primaries = RgbSpaceData::srgb().primaries_as_colorants();
    let adobe_primaries = RgbSpaceData::adobe_rgb().primaries_as_colorants();
    
    dbg!(srgb_primaries);
    assert_eq!(srgb_primaries, adobe_primaries);
}
```
You can run this and the `assert_eq` will pass. You can also observe that if you change the order of the first two lines, the `dbg!(srgb_primaries);` output will become different. That is because in the example above the sRGB primaries will be returned in both calls. But if you change the order, then the AdobeRGB primaries will be returned for both calls.

My suggested fix: Get rid of the caching. There are no benchmarks, so I have not evaluated to what degree this might affect performance. But correctness is more important than performance. An alternative could be to store the colorants as a member in the struct, and compute it once on instantiation. But that would completely disallow RGB spaces with reference whites with `0.0` values in them, as that cause the colorant computation to panic.