### PR TITLE
Remove `RGB::from_xyz` method, add WideRgb for uncontrained rgb values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   subsequent invocations.
 
 
+* **Added**:
+
+* **Changed**:
+
+* **Deprecated**:
+
+* **Removed**:
+  - Remove `RGB::from_xyz` method, which requires XYZ values to be in the range from 0.0 to 1.0;
+    use `XYZ::rgb` instead, as that uses the reference illuminance for scaling.
+
+e **Fixed**:
+  - Fix bug in RgbSpaceData::primaries_as_colorants by removing caching
+
+* **Security**:
+
+
 ## [0.0.4] - 2025-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
+- `WideRgb::clamp` and `WideRgb::compress` methods to create `Rgb` from `WideRgb` values, to pull
+   out-of-gamut values within the colorspace,
+- `WideRgb` type allowing unconstrained, out-of-gamut RGB values
 - Implement strums `EnumIter` on `Observer`. Allows easy iteration over all available observers.
 
 ### Changed
+- Constrained `Rgb` type to in-gamut values only, i.e. all R,G, and B values are required to be the
+  range of [0..=1.0].
+- Renamed `RGB` type to `Rgb`
 - Change the return type of `Observer::spectral_locus_by_index` from `[f64; 2]` to
   `Option<[f64; 2]>`. Allows returning `None` for invalid indices.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,21 +40,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   only the computed matrixes for the first one to call into these methods would be returned in
   subsequent invocations.
 
-
-* **Added**:
-
-* **Changed**:
-
-* **Deprecated**:
-
-* **Removed**:
+### Removed
   - Remove `RGB::from_xyz` method, which requires XYZ values to be in the range from 0.0 to 1.0;
     use `XYZ::rgb` instead, as that uses the reference illuminance for scaling.
 
-e **Fixed**:
+### Fixed
   - Fix bug in RgbSpaceData::primaries_as_colorants by removing caching
 
-* **Security**:
 
 
 ## [0.0.4] - 2025-05-06

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 
-Colorimetry
-===========
 ![Build Status](https://github.com/harbik/colorimetry/actions/workflows/build-and-test.yml/badge.svg)
-
-# Colorimetry
 
 A Rust library for color modeling in illumination and engineering projects, with early JavaScript/WebAssembly support.
 Algorithms follow standards from the CIE, ICC, and IES.
@@ -31,7 +27,7 @@ It intends to provide a comprehensive framework for spectral colorimetry:
   - **CIE 2015 10º**,
 
 
-- **Spectrally based RGB Color Spaces** with transformation matrices between [`RGB`] and [`XYZ`] values for all color spaces and observers
+- **Spectrally based RGB Color Spaces** with transformation matrices between [`Rgb`] and [`XYZ`] values for all color spaces and observers
   - **sRGB**
   - **Adobe RGB**
   - **DisplayP3**
@@ -431,7 +427,7 @@ If any value falls outside this range, the constructor returns an error.
 <summary><strong>Factory functions</strong></summary>
 
 - [`Stimulus::from_srgb`], and [`Stimulus::from_rgb`], create a `Stimulus` of a set of RGB pixel values.
-  The first takes three `u8` arguments, while the second uses a [`RGB`](crate::rgb::RGB) object as argument.
+  The first takes three `u8` arguments, while the second uses a [`Rgb`] object as argument.
   This function allows calculating the perceived color difference between different observers, from the perspective of a single observer.
 
   ```rust
@@ -486,7 +482,7 @@ dual licensed as above, without any additional terms or conditions.
 [`Stimulus::from_srgb`]: https://docs.rs/colorimetry/latest/colorimetry/stimulus/struct.Stimulus.html#method.from_srgb
 [`Stimulus::from_rgb`]: https://docs.rs/colorimetry/latest/colorimetry/stimulus/struct.Stimulus.html#method.from_rgb
 [Colorimetric Observers]: https://docs.rs/colorimetry/latest/colorimetry/observer/index.html
-[`Observer`]: https://docs.rs/colorimetry/latest/colorimetry/observer/struct.Observer.html
+[`Observer`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html
 [`ObserverData`]:https://docs.rs/colorimetry/latest/colorimetry/observer/enum.ObserverData.html 
 [`Observer.xyz`]: https://docs.rs/colorimetry/latest/colorimetry/observer/struct.ObserverData.html#method.xyz
 [`CIE1931`]: https://docs.rs/colorimetry/latest/colorimetry/data/observers/static.CIE1931.html
@@ -494,7 +490,8 @@ dual licensed as above, without any additional terms or conditions.
 [`CIE2015`]: https://docs.rs/colorimetry/latest/colorimetry/data/observers/static.CIE2015.html
 [`CIE2015_10`]: https://docs.rs/colorimetry/latest/colorimetry/data/observers/static.CIE2015_10.html
 [`XYZ`]: https://docs.rs/colorimetry/latest/colorimetry/xyz/struct.XYZ.html
-[`RGB`]: https://docs.rs/colorimetry/latest/colorimetry/rgb/struct.RGB.html
+[`Rgb`]: https://docs.rs/colorimetry/latest/colorimetry/rgb/struct.RGB.html
+[`WideRgb`]: https://docs.rs/colorimetry/latest/colorimetry/widergb/struct.WideRgb.html
 [CIECAM16]: https://docs.rs/colorimetry/latest/colorimetry/cam/struct.CieCam16.html
 [CIELAB]: https://docs.rs/colorimetry/latest/colorimetry/lab/struct.CieLab.html
 [`RgbSpace`]: https://docs.rs/colorimetry/latest/colorimetry/rgbspace/enum.RgbSpace.html

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,8 @@ pub enum CmtError {
     SpectrumNotFound(String),
     #[error("Provide at least {0} values")]
     ProvideAtLeastNValues(usize),
+    #[error("Invalid RGB value")]
+    InvalidRgbValue,
 }
 
 impl From<&str> for CmtError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,4 +30,5 @@ pub mod std_illuminants;
 pub mod stimulus;
 pub mod traits;
 pub mod viewconditions;
+pub mod widergb;
 pub mod xyz;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -144,7 +144,7 @@ impl ObserverData {
     /// The Light trait is implemented by [`StdIlluminant`] and [Illuminant](crate::illuminant::Illuminant).
     ///
     /// [`Colorant`] implments the [`Filter`] trait.
-    /// [`RGB`](crate::rgb::RGB), which represents a display pixel, implements both in this library.
+    /// [`Rgb`](crate::rgb::Rgb), which represents a display pixel, implements both in this library.
     /// As a light, it is the light emitted from the pixel, as a filter it is the RGB-composite
     /// filter which is applied to the underlying standard illuminant of color space.
     pub fn xyz(&self, light: &dyn Light, filter: Option<&dyn Filter>) -> XYZ {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,5 +18,6 @@ pub use super::spectrum::*;
 pub use super::std_illuminants::*;
 pub use super::stimulus::*;
 pub use super::traits::*;
+pub use super::widergb::*;
 pub use super::xyz::*;
 use wasm_bindgen::JsValue;

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -219,9 +219,7 @@ impl Rgb {
     }
 }
 
-
 impl Light for Rgb {
-
     /// Implements the `Light` trait for the `Rgb` struct, allowing an `Rgb` color to be interpreted
     /// as a spectral power distribution (`Spectrum`).
     ///
@@ -261,21 +259,21 @@ impl Light for Rgb {
 impl Filter for Rgb {
     /// Implements the `Filter` trait for the `Rgb` struct, treating an RGB color as a spectral filter function.
     ///
-    /// The `spectrum` method interprets the RGB values as a filter, excluding the reference illuminant. 
-    /// The filter function is then used in combination with a reference illuminant to simulate the resulting 
+    /// The `spectrum` method interprets the RGB values as a filter, excluding the reference illuminant.
+    /// The filter function is then used in combination with a reference illuminant to simulate the resulting
     /// stimulus within the defined RGB color space.
     ///
     /// # Method: `spectrum()`
-    /// - This method calculates the spectral power distribution of the `Rgb` instance by treating each RGB 
+    /// - This method calculates the spectral power distribution of the `Rgb` instance by treating each RGB
     ///   component as a filter over its respective primary spectrum.
-    /// - The resulting spectrum represents the relative transmittance of each primary, scaled by its respective 
+    /// - The resulting spectrum represents the relative transmittance of each primary, scaled by its respective
     ///   luminance weight (`yrgb`), without applying any reference illuminant.
     ///
     /// # Example
     /// ```rust
     /// use colorimetry::prelude::*;
     /// use approx::assert_ulps_eq;
-    /// 
+    ///
     /// // Define an sRGB white color using the CIE 1931 observer
     /// let rgb = Rgb::from_u8(255, 255, 255, None, None);
     ///
@@ -288,16 +286,16 @@ impl Filter for Rgb {
     /// ```
     ///
     /// # Implementation Details
-    /// - The method iterates over the RGB components and their respective primary spectra, treating each 
+    /// - The method iterates over the RGB components and their respective primary spectra, treating each
     ///   component as a filter function.
-    /// - Each component is scaled by its luminance factor (`yrgb`) to accurately reflect the relative 
+    /// - Each component is scaled by its luminance factor (`yrgb`) to accurately reflect the relative
     ///   contribution of each primary to the resulting spectrum.
     /// - The resulting spectrum is returned as an owned `Cow<Spectrum>`.
     ///
     /// # Notes
-    /// - The spectral representation is device-dependent, relying on the primary spectra defined in the 
+    /// - The spectral representation is device-dependent, relying on the primary spectra defined in the
     ///   associated `RgbSpace`.
-    /// - This implementation excludes the reference illuminant, making it suitable for use as a relative filter 
+    /// - This implementation excludes the reference illuminant, making it suitable for use as a relative filter
     ///   that can be combined with any illuminant to produce a specific stimulus.
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = self.space.data().primaries_as_colorants();

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -138,7 +138,7 @@ impl Rgb {
         opt_observer: Option<Observer>,
         opt_rgbspace: Option<RgbSpace>,
     ) -> Result<Self, CmtError> {
-        if r >= 0.0 && r <= 1.0 && g >= 0.0 && g <= 1.0 && b >= 0.0 && b <= 1.0 {
+        if (0.0..=1.0).contains(&r) && (0.0..=1.0).contains(&g) && (0.0..=1.0).contains(&b) {
             let observer = opt_observer.unwrap_or_default();
             let space = opt_rgbspace.unwrap_or_default();
             Ok(Rgb {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,8 +1,62 @@
+//! # Rgb: In gamut RGB Color Representation of a Color Stimulus
+//!
+//! This module provides the `Rgb` struct, a representation of a color stimulus using Red, Green, and Blue
+//! (RGB) floating-point values constrained to the `[0.0, 1.0]` range. Unlike the `WideRgb` type, which allows
+//! for out-of-gamut colors, `Rgb` is strictly limited to the device’s RGB color space gamut, ensuring that
+//! all values are within the valid range for rendering and display.
+//!
+//! ## Key Features
+//! - **Constrained RGB Values:** The `Rgb` struct enforces that all RGB values must be within the range
+//!   `[0.0, 1.0]`. Attempts to create values outside this range will result in an error.
+//! - **Color Space Support:** Supports various RGB color spaces through the `RgbSpace` type, including sRGB,
+//!   Adobe RGB, and custom-defined spaces.
+//! - **Observer Customization:** Allows the use of different colorimetric observers (e.g., CIE 1931, CIE 2015),
+//!   enhancing accuracy in color conversions.
+//! - **Data Conversions:** Provides methods to convert RGB values to `XYZ` tristimulus values, and to u8 and u16
+//!   arrays for compatibility with 8-bit and 16-bit RGB formats.
+//! - **Validation:** Ensures that all RGB values are validated during creation, preventing invalid color data.
+//!
+//! ## Example Usage
+//!
+//! ```rust
+//! use colorimetry::rgb::Rgb;
+//!
+//! // Creating a valid Rgb instance
+//! let rgb = Rgb::new(0.5, 0.3, 0.7, None, None).unwrap();
+//!
+//! // Convert to a u8 array for image processing
+//! let u8_rgb: [u8; 3] = rgb.into();
+//!
+//! // Convert to XYZ tristimulus values
+//! let xyz = rgb.xyz();
+//!
+//! println!("RGB as u8: {:?}", u8_rgb);
+//! println!("XYZ values: {:?}", xyz.values());
+//! ```
+//!
+//! ## Error Handling
+//! - The `Rgb::new()` method returns an `Err(CmtError::InvalidRgbValue)` if any of the provided RGB values
+//!   are outside the `[0.0, 1.0]` range.
+//! - The `from_u8()` and `from_u16()` methods internally clamp values to ensure they remain within the valid range.
+//!
+//! ## Notes
+//! - Unlike the `WideRgb` type, which supports out-of-gamut colors, `Rgb` enforces strict adherence to the
+//!   `[0.0, 1.0]` range. As such, it is ideal for cases where data must be strictly constrained to the device’s
+//!   rendering gamut.
+//! - The `observer` field is optional but can be specified to provide more accurate conversions to `XYZ` values
+//!   based on specific viewing conditions.
+//!
+//! ## Testing
+//! - Comprehensive unit tests verify RGB value validation, conversion methods, and compatibility with different
+//!   data formats, including `u8` and `f64` arrays.
+
 use crate::{
     colorant::Colorant,
     data::observers::CIE1931,
+    error::CmtError,
     illuminant::Illuminant,
     observer::Observer,
+    prelude::WideRgb,
     rgbspace::RgbSpace,
     spectrum::Spectrum,
     stimulus::Stimulus,
@@ -14,17 +68,43 @@ use nalgebra::{Matrix3, Vector3};
 use std::borrow::Cow;
 use wasm_bindgen::prelude::wasm_bindgen;
 
-/// Representation of a color stimulus in a set of Red, Green, and Blue (RGB) values,
-/// representing its relative composition using standard primaries.
+/// Represents a color stimulus using Red, Green, and Blue (RGB) values constrained to the `[0.0, 1.0]` range.
+/// Each component is a floating-point value representing the relative intensity of the respective primary color
+/// within a defined RGB color space.
 ///
-/// RGB values are commonly used in digital images, with the relative intensity
-/// of the primaries defined as three 8-bit values, with range from 0 to 255.
-/// As ooposed to CIE XYZ tristimulus values, which used imaginary primaries,
-/// displays use real primaries, typically defined in the CIE 1931 diagram.
-/// They cover a triangular area, referred to the _color gamut_ of a display.
+/// Unlike the CIE XYZ tristimulus values, which use imaginary primaries, RGB values are defined using real primaries
+/// based on a specific color space. These primaries typically form a triangular area within a CIE (x,y) chromaticity
+/// diagram, representing the gamut of colors the device can reproduce.
+///
+/// # Fields
+/// - `space`: The RGB color space defining the specific primaries and white point. Common spaces include sRGB, Adobe RGB, and custom-defined spaces.
+/// - `observer`: The colorimetric observer that defines how the color is perceived. Default is the CIE 1931 standard observer,
+///   but more recent observers, such as the CIE 2015 cone fundamentals, can be specified for improved accuracy.
+/// - `rgb`: A 3-element vector representing the red, green, and blue components as floating-point values in the range `[0.0, 1.0]`.
+///
+/// # Usage
+/// The `Rgb` struct is used to encapsulate color information in a device-independent manner, allowing for accurate color
+/// representation, conversion, and manipulation within defined RGB spaces. It is particularly useful for applications
+/// involving color management, digital imaging, and rendering where strict adherence to gamut boundaries is required.
+///
+/// # Example
+/// ```rust
+/// # use colorimetry::rgb::Rgb;
+/// # use approx::assert_abs_diff_eq;
+///
+/// // Create an sRGB color with normalized RGB values
+/// let rgb = Rgb::new(0.5, 0.25, 0.75, None, None).unwrap();
+/// assert_abs_diff_eq!(rgb.values().as_ref(), [0.5, 0.25, 0.75].as_ref(), epsilon = 1e-6);
+/// ```
+///
+/// # Notes
+/// - The `Rgb` struct strictly enforces the `[0.0, 1.0]` range for each component. Any attempt to create values
+///   outside this range will result in an error.
+/// - The `observer` field allows for color conversion accuracy under different lighting and viewing conditions,
+///   enhancing the reliability of transformations to other color spaces such as XYZ.
 #[wasm_bindgen]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct RGB {
+pub struct Rgb {
     /// The RGB color space the color values are using. Often this is the _sRGB_
     /// color space, which is rather small.
     pub(crate) space: RgbSpace,
@@ -38,24 +118,36 @@ pub struct RGB {
     pub(crate) rgb: Vector3<f64>,
 }
 
-impl RGB {
-    /// Construct a RGB instance from red, green, and blue values in the range from 0 to 1,
-    /// with an `Observer` and an optional `RgbSpace`.
-    /// When using online RGB data, when observer and color space or color profile are not explicititely specfied,
-    /// `Observer::Std1931`, and `RgbSpace::SRGB` are implied, and those are the defaults here too.
+impl Rgb {
+    /// Creates a new `Rgb` instance with the specified red, green, and blue values.
+    /// # Arguments
+    /// - `r`: Red component, in the range from 0.0 to 1.0
+    /// - `g`: Green component, in the range from 0.0 to 1.0
+    /// - `b`: Blue component, in the range from 0.0 to 1.0
+    /// - `observer`: Optional observer, defaults to `Observer::Std1931`
+    /// - `space`: Optional RGB color space, defaults to `RgbSpace::SRGB`
+    /// # Returns
+    /// A new `Rgb` instance with the specified RGB values and color space.
+    /// # Errors
+    /// - InvalidRgbValue: at least one of the RGB values is outside the range from 0.0 to 1.0.
+    ///     
     pub fn new(
         r: f64,
         g: f64,
         b: f64,
-        observer: Option<Observer>,
-        space: Option<RgbSpace>,
-    ) -> Self {
-        let observer = observer.unwrap_or_default();
-        let space = space.unwrap_or_default();
-        RGB {
-            rgb: Vector3::new(r, g, b),
-            observer,
-            space,
+        opt_observer: Option<Observer>,
+        opt_rgbspace: Option<RgbSpace>,
+    ) -> Result<Self, CmtError> {
+        if r >= 0.0 && r <= 1.0 && g >= 0.0 && g <= 1.0 && b >= 0.0 && b <= 1.0 {
+            let observer = opt_observer.unwrap_or_default();
+            let space = opt_rgbspace.unwrap_or_default();
+            Ok(Rgb {
+                rgb: Vector3::new(r, g, b),
+                observer,
+                space,
+            })
+        } else {
+            Err(CmtError::InvalidRgbValue)
         }
     }
 
@@ -74,7 +166,8 @@ impl RGB {
         let [r, g, b] = [r_u8, g_u8, b_u8]
             .map(|v| (v as f64 / 255.0).clamp(0.0, 1.0))
             .map(|v| space.data().gamma.decode(v));
-        RGB::new(r, g, b, observer, Some(space))
+        // unwrap OK as derived from u8 values and clamped to 0.0..1.0
+        Rgb::new(r, g, b, observer, Some(space)).unwrap()
     }
 
     /// Construct a RGB instance from red, green, and blue u16 values in the range from 0 to 1.
@@ -92,14 +185,15 @@ impl RGB {
         let [r, g, b] = [r_u16, g_u16, b_u16]
             .map(|v| (v as f64 / 65_535.0).clamp(0.0, 1.0))
             .map(|v| space.data().gamma.decode(v));
-        RGB::new(r, g, b, observer, Some(space))
+        // unwrap OK as derived from u16 values and clamped to 0.0..1.0
+        Rgb::new(r, g, b, observer, Some(space)).unwrap()
     }
 
     /// Returns the RGB values as an array with the red, green, and blue values respectively
     ///
     /// ```rust
-    /// # use colorimetry::rgb::RGB;
-    /// let rgb = RGB::new(0.1, 0.2, 0.3, None, None);
+    /// # use colorimetry::rgb::Rgb;
+    /// let rgb = Rgb::new(0.1, 0.2, 0.3, None, None).unwrap();
     /// let [r, g, b] = rgb.values();
     /// assert_eq!([r, g, b], [0.1, 0.2, 0.3]);
     /// ```
@@ -123,42 +217,32 @@ impl RGB {
             xyzn,
         }
     }
-
-    // /// Creates a callback of closure function, which takes a set or RGB values, within a color
-    // /// space and viewed as one observer, and returns a new set of RGB values, represeting the
-    // /// stimulus in another color space, and using another observer.
-    // ///
-    // /// This conversion uses the spectral represenations of the primaries through the color space
-    // /// `Spectra` function, to create a  transformation matrix.
-    // pub fn convert(
-    //     obs_from: Observer,
-    //     space_from: RgbSpace,
-    //     obs: Observer,
-    //     space: RgbSpace,
-    // ) -> Box<dyn Fn(&Vector3<f64>) -> Vector3<f64>> {
-    //     todo!()
-    // }
-
-    // /// Transform a set of RGB values, defining a stimulus for one standard observer, into a set of
-    // /// RGB values representing the same stimulus for different standard observer or special
-    // /// observer.  On initial use this function calculates a transformation matrix based on the
-    // /// colorimetric tristimulus values of the respective primaries.
-    // pub fn transform(&self, obs_from: &Observer) -> Self {
-    //     todo!()
-    // }
-
-    /*
-    /// Creates a [Spectrum] from an [RGB] value, using the spectral primaries of its color space.
-    /// See also [Spectrum::rgb] and [Spectrum::srgb].
-    pub fn spectrum(&self) -> Spectrum {
-        let p = &self.space.data().0.primaries;
-        let yrgb = CIE1931.rgb2xyz(&RgbSpace::SRGB).row(1);
-        self.data.iter().zip(yrgb.iter()).zip(p.iter()).map(|((v,w),s)|*v * *w * *s).sum::<Spectrum>().set_category(Category::Stimulus)
-    }
-     */
 }
 
-impl Light for RGB {
+
+impl Light for Rgb {
+
+    /// Implements the `Light` trait for the `Rgb` struct, allowing an `Rgb` color to be interpreted
+    /// as a spectral power distribution (`Spectrum`).
+    ///
+    /// The `spectrum` method converts the RGB values into a spectral representation based on the
+    /// primaries defined by the associated RGB color space and the current observer.
+    ///
+    /// # Method: `spectrum()`
+    /// - This method calculates the spectral power distribution of the `Rgb` instance by combining the
+    ///   RGB values with the respective primary spectra.
+    /// - Each RGB component is weighted by its corresponding luminance factor (`yrgb`) and primary spectrum,
+    ///   effectively converting the RGB values into a continuous spectrum representation.
+    ///
+    /// # Implementation Details
+    /// - The method iterates over the RGB components and the respective primary spectra.
+    /// - Each component value is scaled by its corresponding luminance weight (`yrgb`) and then combined
+    ///   with the primary spectrum using a weighted sum.
+    /// - The resulting `Spectrum` is returned as an owned `Cow<Spectrum>`.
+    ///
+    /// # Notes
+    /// - The spectral representation is device-dependent and based on the primaries defined by the `RgbSpace`.
+    /// - The observer's data is used to apply luminance scaling, enhancing perceptual accuracy.
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = &self.space.data().primaries;
         let rgb2xyz = self.observer.data().rgb2xyz(&self.space);
@@ -174,23 +258,47 @@ impl Light for RGB {
     }
 }
 
-impl Filter for RGB {
-    /**
-        An RGB pixel as a filter.
-
-        This excludes the reference white light.
-        Ii is the filter function only, which is used in combination with a reference illuminant to achieve
-        a stimulus in accordance with the colorspace in which is defined.
-
-        ```
-        use colorimetry::prelude::*;
-
-        // rgb white in using CIE1931 standard observer, and sRGB color space.
-        let rgb = RGB::from_u8(255, 255, 255, None, None);
-        let d65: XYZ = CIE1931.xyz(&StdIlluminant::D65, Some(&rgb));
-        approx::assert_ulps_eq!(d65, XYZ_D65WHITE, epsilon=1E-2);
-        ```
-    */
+impl Filter for Rgb {
+    /// Implements the `Filter` trait for the `Rgb` struct, treating an RGB color as a spectral filter function.
+    ///
+    /// The `spectrum` method interprets the RGB values as a filter, excluding the reference illuminant. 
+    /// The filter function is then used in combination with a reference illuminant to simulate the resulting 
+    /// stimulus within the defined RGB color space.
+    ///
+    /// # Method: `spectrum()`
+    /// - This method calculates the spectral power distribution of the `Rgb` instance by treating each RGB 
+    ///   component as a filter over its respective primary spectrum.
+    /// - The resulting spectrum represents the relative transmittance of each primary, scaled by its respective 
+    ///   luminance weight (`yrgb`), without applying any reference illuminant.
+    ///
+    /// # Example
+    /// ```rust
+    /// use colorimetry::prelude::*;
+    /// use approx::assert_ulps_eq;
+    /// 
+    /// // Define an sRGB white color using the CIE 1931 observer
+    /// let rgb = Rgb::from_u8(255, 255, 255, None, None);
+    ///
+    /// // Retrieve the spectral representation
+    /// let spectrum = Filter::spectrum(&rgb);
+    ///
+    /// // Compare with the CIE D65 reference white point
+    /// let d65: XYZ = CIE1931.xyz(&StdIlluminant::D65, Some(&rgb));
+    /// approx::assert_ulps_eq!(d65, XYZ_D65WHITE, epsilon = 1e-2);
+    /// ```
+    ///
+    /// # Implementation Details
+    /// - The method iterates over the RGB components and their respective primary spectra, treating each 
+    ///   component as a filter function.
+    /// - Each component is scaled by its luminance factor (`yrgb`) to accurately reflect the relative 
+    ///   contribution of each primary to the resulting spectrum.
+    /// - The resulting spectrum is returned as an owned `Cow<Spectrum>`.
+    ///
+    /// # Notes
+    /// - The spectral representation is device-dependent, relying on the primary spectra defined in the 
+    ///   associated `RgbSpace`.
+    /// - This implementation excludes the reference illuminant, making it suitable for use as a relative filter 
+    ///   that can be combined with any illuminant to produce a specific stimulus.
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = self.space.data().primaries_as_colorants();
         let rgb2xyz = self.observer.data().rgb2xyz(&self.space);
@@ -205,27 +313,27 @@ impl Filter for RGB {
     }
 }
 
-impl AsRef<Vector3<f64>> for RGB {
+impl AsRef<Vector3<f64>> for Rgb {
     fn as_ref(&self) -> &Vector3<f64> {
         &self.rgb
     }
 }
 
 /// Clamped RGB values as a u8 array. Uses gamma function.
-impl From<RGB> for [u8; 3] {
-    fn from(rgb: RGB) -> Self {
+impl From<Rgb> for [u8; 3] {
+    fn from(rgb: Rgb) -> Self {
         let data: &[f64; 3] = rgb.rgb.as_ref();
         data.map(|v| (rgb.space.data().gamma.encode(v.clamp(0.0, 1.0)) * 255.0).round() as u8)
     }
 }
 
-impl From<RGB> for [f64; 3] {
-    fn from(rgb: RGB) -> Self {
+impl From<Rgb> for [f64; 3] {
+    fn from(rgb: Rgb) -> Self {
         rgb.values()
     }
 }
 
-impl AbsDiffEq for RGB {
+impl AbsDiffEq for Rgb {
     type Epsilon = f64;
 
     fn default_epsilon() -> Self::Epsilon {
@@ -237,7 +345,7 @@ impl AbsDiffEq for RGB {
     }
 }
 
-impl approx::UlpsEq for RGB {
+impl approx::UlpsEq for Rgb {
     fn default_max_ulps() -> u32 {
         f64::default_max_ulps()
     }
@@ -278,7 +386,7 @@ mod rgb_tests {
 
     #[test]
     fn get_values_f64() {
-        let rgb = RGB::new(0.1, 0.2, 0.3, None, None);
+        let rgb = Rgb::new(0.1, 0.2, 0.3, None, None).unwrap();
         let [r, g, b] = <[f64; 3]>::from(rgb);
         assert_eq!(r, 0.1);
         assert_eq!(g, 0.2);
@@ -287,7 +395,7 @@ mod rgb_tests {
 
     #[test]
     fn get_values_u8() {
-        let rgb = RGB::new(0.1, 0.2, 0.3, None, None);
+        let rgb = Rgb::new(0.1, 0.2, 0.3, None, None).unwrap();
         let [r, g, b] = <[u8; 3]>::from(rgb);
         assert_eq!(r, 89);
         assert_eq!(g, 124);

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -76,12 +76,6 @@ use wasm_bindgen::prelude::wasm_bindgen;
 /// based on a specific color space. These primaries typically form a triangular area within a CIE (x,y) chromaticity
 /// diagram, representing the gamut of colors the device can reproduce.
 ///
-/// # Fields
-/// - `space`: The RGB color space defining the specific primaries and white point. Common spaces include sRGB, Adobe RGB, and custom-defined spaces.
-/// - `observer`: The colorimetric observer that defines how the color is perceived. Default is the CIE 1931 standard observer,
-///   but more recent observers, such as the CIE 2015 cone fundamentals, can be specified for improved accuracy.
-/// - `rgb`: A 3-element vector representing the red, green, and blue components as floating-point values in the range `[0.0, 1.0]`.
-///
 /// # Usage
 /// The `Rgb` struct is used to encapsulate color information in a device-independent manner, allowing for accurate color
 /// representation, conversion, and manipulation within defined RGB spaces. It is particularly useful for applications

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -95,13 +95,6 @@ impl RGB {
         RGB::new(r, g, b, observer, Some(space))
     }
 
-    pub fn from_xyz(xyz: XYZ, space: RgbSpace) -> Self {
-        let xyz2rgb = xyz.observer.data().xyz2rgb(space);
-        let xyz0 = xyz.xyz.unwrap_or(xyz.xyzn);
-        let &[r, g, b] = (xyz2rgb * xyz0).as_ref();
-        RGB::new(r, g, b, Some(xyz.observer), Some(space))
-    }
-
     /// Returns the RGB values as an array with the red, green, and blue values respectively
     ///
     /// ```rust

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -33,8 +33,8 @@ use crate::{
     observer::ObserverData,
     physics::C,
     physics::{gaussian_peak_one, led_ohno, planck, sigma_from_fwhm, stefan_boltzmann, wavelength},
-    rgb::RGB,
     std_illuminants::StdIlluminant,
+    widergb::WideRgb,
 };
 
 /// The wavelength range of the spectrums supported by this library.
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn test_spectrum_from_rgb() {
-        let white: Stimulus = RGB::new(1.0, 1.0, 1.0, None, None).into();
+        let white: Stimulus = Rgb::new(1.0, 1.0, 1.0, None, None).unwrap().into();
         approx::assert_ulps_eq!(
             CIE1931.xyz_from_spectrum(&white, None),
             CIE1931.xyz_d65().set_illuminance(100.0),

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use crate::{
-    illuminant::Illuminant, observer::ObserverData, rgb::RGB, spectrum::Spectrum, traits::Light,
+    illuminant::Illuminant, observer::ObserverData, rgb::Rgb, spectrum::Spectrum, traits::Light,
+    widergb::WideRgb,
 };
 
 #[derive(Clone)]
@@ -36,7 +37,7 @@ impl Stimulus {
     /// a linear combination of the spectral primaries, which are Gaudssian filtered components in
     /// this library.
     pub fn from_srgb(r_u8: u8, g_u8: u8, b_u8: u8) -> Self {
-        let rgb = RGB::from_u8(
+        let rgb = Rgb::from_u8(
             r_u8,
             g_u8,
             b_u8,
@@ -49,7 +50,7 @@ impl Stimulus {
     /// A spectral composition of a display pixel, set to three sRGB color values.  The spectrum is
     /// a linear combination of the spectral primaries, which are Gaudssian filtered components in
     /// this library.
-    pub fn from_rgb(rgb: RGB) -> Self {
+    pub fn from_rgb(rgb: Rgb) -> Self {
         rgb.into()
     }
 }
@@ -68,7 +69,7 @@ impl Sum for Stimulus {
     }
 }
 
-/// Spectral representation the color of a display pixel, described by a [RGB]
+/// Spectral representation the color of a display pixel, described by a [`Rgb`]
 /// instance.
 ///
 /// It uses a linear combination of the spectral primaries as defined for a particular
@@ -77,8 +78,8 @@ impl Sum for Stimulus {
 /// but you can also use your own color space based on primaries measured by a spectrometer.
 /// Spectral representations of pixels allow color matching for arbitrary observers,
 /// not only the CIE 1931 standard observer.
-impl From<RGB> for Stimulus {
-    fn from(rgb: RGB) -> Self {
+impl From<Rgb> for Stimulus {
+    fn from(rgb: Rgb) -> Self {
         let prim = &rgb.space.data().primaries;
         let rgb2xyz = rgb.observer.data().rgb2xyz(&rgb.space);
         let yrgb = rgb2xyz.row(1);

--- a/src/widergb.rs
+++ b/src/widergb.rs
@@ -1,4 +1,4 @@
-//! # WideRgb Module
+//! # WideRgb: Color Representation allowing out-of-gamut colors for a given RGB color space.
 //!
 //! This module provides the `WideRgb` struct, a representation of a color stimulus using unconstrained
 //! Red, Green, and Blue (RGB) floating-point values within a specified RGB color space. Unlike typical
@@ -61,12 +61,6 @@ use wasm_bindgen::prelude::wasm_bindgen;
 /// Represents a color stimulus using unconstrained Red, Green, and Blue (RGB) floating-point values
 /// within a device's RGB color space. The values can extend beyond the typical 0.0 to 1.0 range,
 /// allowing for out-of-gamut colors that cannot be accurately represented by the device.
-///
-/// # Fields
-/// - `space`: The RGB color space the color values are using. Often this is the _sRGB_ color space, which is rather small.
-/// - `observer`: Reference to the colorimetric observer being used. This is almost always the CIE 1931 standard observer,
-///   but other standard observers can be used to improve color management quality.
-/// - `rgb`: The RGB values as a 3-element vector.
 pub struct WideRgb {
     /// The RGB color space the color values are using. Often this is the _sRGB_
     /// color space, which is rather small.

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -337,17 +337,20 @@ impl XYZ {
     ///
     /// This method scales the XYZ values relative to the luminous value of the reference white point,
     /// which does not have to be **100.0**. The scaling is necessary to ensure that the XYZ values
-    /// are normalized to the range **0.0 to 1.0**, allowing the resulting RGB values to remain
-    /// within the gamut of the target RGB space.
+    /// are normalized to the range **0.0 to 1.0**.
     ///
-    /// For non-emissive, non-fluorescent colors, the luminance (`Y`) value should generally be
-    /// **less than or equal to the reference white** to create correct RGB values.
+    /// For non-emissive, non-fluorescent colors, luminance (`Y`) values should be **less than or
+    /// equal to the reference white** to create correct RGB values.  Values greater than luminance of the
+    /// reference white will result in RGB values which can not be rendered, and have to be clipped
+    /// or remapped depanding on the colorimetric intent of an application.
+    /// For example, these would create negative RGB values or values larger than 255 in the sRGB
+    /// space when converting the values from floating point to integer values.
     ///
     /// # Arguments
     ///
     /// - `self`: The XYZ color values to be converted.
-    /// - `rgb_space`: The target RGB space identifier (e.g., `sRGB`, `Adobe RGB`).
-    /// - `white`: The luminous value of the reference white point used for scaling.
+    /// - `rgb_space`: The target RGB space identifier (e.g., `sRGB`, `Adobe RGB`), uses the default
+    ///   sRGB space if `None`` is supplied.
     ///
     /// # Returns
     ///

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -334,11 +334,10 @@ impl XYZ {
         self.try_into()
     }
 
-
     /// Converts a set of **XYZ tristimulus values** to **RGB values** using the specified RGB space.
     ///
     /// This method scales the XYZ values to the luminous value of the reference white, so it doesn't have to 100.0.
-    /// The scaling is necessary as the XYZ to RGB matrix requires the tristimulus values to be in the range of 
+    /// The scaling is necessary as the XYZ to RGB matrix requires the tristimulus values to be in the range of
     /// 0.0 to 1.0, for the RGB values to be winthing the gamut of the RGB space.
     ///
     /// # Arguments

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -333,22 +333,25 @@ impl XYZ {
     pub fn cct(self) -> Result<crate::cct::CCT, CmtError> {
         self.try_into()
     }
-
-    /// Converts a set of **XYZ tristimulus values** to **RGB values** using the specified RGB space.
+    /// Converts a set of **XYZ tristimulus values** to **RGB values** within the specified RGB space.
     ///
-    /// This method scales the XYZ values to the luminous value of the reference white, so it doesn't have to 100.0.
-    /// The scaling is necessary as the XYZ to RGB matrix requires the tristimulus values to be in the range of
-    /// 0.0 to 1.0, for the RGB values to be winthing the gamut of the RGB space.
+    /// This method scales the XYZ values relative to the luminous value of the reference white point, 
+    /// which does not have to be **100.0**. The scaling is necessary to ensure that the XYZ values 
+    /// are normalized to the range **0.0 to 1.0**, allowing the resulting RGB values to remain 
+    /// within the gamut of the target RGB space.
+    ///
+    /// For non-emissive, non-fluorescent colors, the luminance (`Y`) value should generally be 
+    /// **less than or equal to the reference white** to create correct RGB values.
     ///
     /// # Arguments
     ///
     /// - `self`: The XYZ color values to be converted.
-    /// - `rgb_space`: The RGB space identifier (e.g., sRGB, Adobe RGB).
-    /// - `white`: The luminous value of the reference white point.
+    /// - `rgb_space`: The target RGB space identifier (e.g., `sRGB`, `Adobe RGB`).
+    /// - `white`: The luminous value of the reference white point used for scaling.
     ///
     /// # Returns
     ///
-    /// - A set of normalized **RGB values** corresponding to the specified RGB space.
+    /// A set of normalized **RGB values**, adjusted to the specified RGB space.
     pub fn rgb(&self, space: Option<RgbSpace>) -> RGB {
         let space = space.unwrap_or_default();
         let xyz = self.xyz.unwrap_or(self.xyzn);

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -334,9 +334,22 @@ impl XYZ {
         self.try_into()
     }
 
-    /// Convert a set of XYZ tristimulus values to RGB values, using the given RGB space identifier.
-    /// This method requires the luminous value of the reference white, which is typically set to 100.0,
-    /// or, less common, 1.0, but any other value can be used as well.
+
+    /// Converts a set of **XYZ tristimulus values** to **RGB values** using the specified RGB space.
+    ///
+    /// This method scales the XYZ values to the luminous value of the reference white, so it doesn't have to 100.0.
+    /// The scaling is necessary as the XYZ to RGB matrix requires the tristimulus values to be in the range of 
+    /// 0.0 to 1.0, for the RGB values to be winthing the gamut of the RGB space.
+    ///
+    /// # Arguments
+    ///
+    /// - `self`: The XYZ color values to be converted.
+    /// - `rgb_space`: The RGB space identifier (e.g., sRGB, Adobe RGB).
+    /// - `white`: The luminous value of the reference white point.
+    ///
+    /// # Returns
+    ///
+    /// - A set of normalized **RGB values** corresponding to the specified RGB space.
     pub fn rgb(&self, space: Option<RgbSpace>) -> RGB {
         let space = space.unwrap_or_default();
         let xyz = self.xyz.unwrap_or(self.xyzn);

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -335,12 +335,12 @@ impl XYZ {
     }
     /// Converts a set of **XYZ tristimulus values** to **RGB values** within the specified RGB space.
     ///
-    /// This method scales the XYZ values relative to the luminous value of the reference white point, 
-    /// which does not have to be **100.0**. The scaling is necessary to ensure that the XYZ values 
-    /// are normalized to the range **0.0 to 1.0**, allowing the resulting RGB values to remain 
+    /// This method scales the XYZ values relative to the luminous value of the reference white point,
+    /// which does not have to be **100.0**. The scaling is necessary to ensure that the XYZ values
+    /// are normalized to the range **0.0 to 1.0**, allowing the resulting RGB values to remain
     /// within the gamut of the target RGB space.
     ///
-    /// For non-emissive, non-fluorescent colors, the luminance (`Y`) value should generally be 
+    /// For non-emissive, non-fluorescent colors, the luminance (`Y`) value should generally be
     /// **less than or equal to the reference white** to create correct RGB values.
     ///
     /// # Arguments


### PR DESCRIPTION
Remove  (old) `RGB::from_xyz` method, which required XYZ values to be in the range from 0.0 to 1.0.
Use `XYZ::rgb` instead, which uses the reference illuminance for scaling.
Improved documentation.