### PR TITLE
Fix multiple bugs around `spectral_locus_index_min` and `spectral_locus_index_max`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Implement strums `EnumIter` on `Observer`. Allows easy iteration over all available observers.
 
+### Changed
+- Change the return type of `Observer::spectral_locus_by_index` from `[f64; 2]` to
+  `Option<[f64; 2]>`. Allows returning `None` for invalid indices.
+
 ### Fixed
 - Fix caching bug in `Observer::spectral_locus_index_min` and
   `Observer::spectral_locus_index_max`. Previously only the values for the first
   observer it was called on was returned for all subsequent calls.
 - Fix caching bug in `RgbSpaceData::primaries_as_colorants`. Previously only the values
   for the first colorspace it was called on was returned for all subsequent calls.
+- Fix `Observer::spectral_locus_index_min` and `Observer::spectral_locus_index_max` to
+  not panic for the `Std2015` observer.
 - Fix caching bug in `Observer::rgb2xyz` and `Observer::xyz2rgb`. If multiple observers are used,
   only the computed matrixes for the first one to call into these methods would be returned in
   subsequent invocations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   for the first colorspace it was called on was returned for all subsequent calls.
 - Fix `Observer::spectral_locus_index_min` and `Observer::spectral_locus_index_max` to
   not panic for the `Std2015` observer.
+- Slightly relax constraints on x-y values in `XYZ::from_chromaticity`. This allows converting
+  the spectral locus positions of all included observers to chromaticity coordinates and back
+  to XYZ values again.
 - Fix caching bug in `Observer::rgb2xyz` and `Observer::xyz2rgb`. If multiple observers are used,
   only the computed matrixes for the first one to call into these methods would be returned in
   subsequent invocations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * **Security**: in case of vulnerabilities.
 
 ## Unreleased
+### Added
+- Implement strums `EnumIter` on `Observer`. Allows easy iteration over all available observers.
 
 ### Fixed
+- Fix caching bug in `Observer::spectral_locus_index_min` and
+  `Observer::spectral_locus_index_max`. Previously only the values for the first
+  observer it was called on was returned for all subsequent calls.
+- Fix caching bug in `RgbSpaceData::primaries_as_colorants`. Previously only the values
+  for the first colorspace it was called on was returned for all subsequent calls.
 - Fix caching bug in `Observer::rgb2xyz` and `Observer::xyz2rgb`. If multiple observers are used,
   only the computed matrixes for the first one to call into these methods would be returned in
   subsequent invocations.

--- a/examples/spectral_locus.rs
+++ b/examples/spectral_locus.rs
@@ -1,17 +1,22 @@
 // to run this example use:
 //  `cargo run --example spectral_locus`
-use colorimetry::prelude::*;
+use colorimetry::observer::Observer;
+use strum::IntoEnumIterator;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let nm_min = CIE1931.spectral_locus_nm_min();
-    let nm_max = CIE1931.spectral_locus_nm_max();
-    println!("Spectral locus");
-    println!("nm\tx\t y");
-    for nm in nm_min..=nm_max {
-        // unwrap OK because nm is in range
-        let xyz = CIE1931.spectral_locus_by_nm(nm).unwrap();
-        let [x, y] = xyz.chromaticity();
-        println!("{nm}\t{x:.4}\t{y:.4}");
+    for observer in Observer::iter() {
+        let nm_min = observer.data().spectral_locus_nm_min();
+        let nm_max = observer.data().spectral_locus_nm_max();
+        println!("Spectral locus for {observer:?} goes from {nm_min} to {nm_max}:");
+        println!("nm\tx\t y");
+        for nm in nm_min..=nm_max {
+            // unwrap OK because nm is in range
+            let xyz = observer.data().spectral_locus_by_nm(nm).unwrap();
+            let [x, y] = xyz.chromaticity();
+            println!("{nm}\t{x:.4}\t{y:.4}");
+        }
+        println!("==========================");
     }
+
     Ok(())
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -353,25 +353,21 @@ impl ObserverData {
     ///
     /// Any further spectral locus points will hover around this edge, and will not have a unique wavelength.
     pub fn spectral_locus_index_min(&self) -> usize {
-        static MIN: OnceLock<usize> = OnceLock::new();
-        *MIN.get_or_init(|| {
-            const START: usize = 100;
-            let mut lp =
-                LineAB::new(self.spectral_locus_by_index(START), [0.33333, 0.33333]).unwrap();
-            let mut m = START - 1;
-            loop {
-                let l = LineAB::new(self.spectral_locus_by_index(m), [0.33333, 0.33333]).unwrap();
-                match (m, l.angle_diff(lp)) {
-                    (0, d) if d > -f64::EPSILON => break m + 1,
-                    (0, _) => break 0,
-                    (1.., d) if d > -f64::EPSILON => break m,
-                    _ => {
-                        m -= 1;
-                        lp = l;
-                    }
+        const START: usize = 100;
+        let mut lp = LineAB::new(self.spectral_locus_by_index(START), [0.33333, 0.33333]).unwrap();
+        let mut m = START - 1;
+        loop {
+            let l = LineAB::new(self.spectral_locus_by_index(m), [0.33333, 0.33333]).unwrap();
+            match (m, l.angle_diff(lp)) {
+                (0, d) if d > -f64::EPSILON => break m + 1,
+                (0, _) => break 0,
+                (1.., d) if d > -f64::EPSILON => break m,
+                _ => {
+                    m -= 1;
+                    lp = l;
                 }
             }
-        })
+        }
     }
 
     pub fn spectral_locus_nm_min(&self) -> usize {
@@ -382,25 +378,21 @@ impl ObserverData {
     ///
     /// Any further spectral locus points will hover around this edge.
     pub fn spectral_locus_index_max(&self) -> usize {
-        static MAX: OnceLock<usize> = OnceLock::new();
-        *MAX.get_or_init(|| {
-            const START: usize = 300;
-            let mut lp =
-                LineAB::new(self.spectral_locus_by_index(START), [0.33333, 0.33333]).unwrap();
-            let mut m = START + 1;
-            loop {
-                let l = LineAB::new(self.spectral_locus_by_index(m), [0.33333, 0.33333]).unwrap();
-                match (m, l.angle_diff(lp)) {
-                    (400, d) if d < f64::EPSILON => break m - 1,
-                    (400, _) => break 400,
-                    (..400, d) if d < f64::EPSILON => break m - 1,
-                    _ => {
-                        m += 1;
-                        lp = l;
-                    }
+        const START: usize = 300;
+        let mut lp = LineAB::new(self.spectral_locus_by_index(START), [0.33333, 0.33333]).unwrap();
+        let mut m = START + 1;
+        loop {
+            let l = LineAB::new(self.spectral_locus_by_index(m), [0.33333, 0.33333]).unwrap();
+            match (m, l.angle_diff(lp)) {
+                (400, d) if d < f64::EPSILON => break m - 1,
+                (400, _) => break 400,
+                (..400, d) if d < f64::EPSILON => break m - 1,
+                _ => {
+                    m += 1;
+                    lp = l;
                 }
             }
-        })
+        }
     }
 
     pub fn spectral_locus_nm_max(&self) -> usize {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -65,6 +65,7 @@ use std::{
     borrow::{Borrow, Cow},
     sync::OnceLock,
 };
+use strum_macros::EnumIter;
 use wasm_bindgen::{convert::IntoWasmAbi, prelude::wasm_bindgen};
 
 /**
@@ -76,7 +77,7 @@ use wasm_bindgen::{convert::IntoWasmAbi, prelude::wasm_bindgen};
 */
 #[cfg(not(feature = "supplemental-observers"))]
 #[wasm_bindgen]
-#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug, EnumIter)]
 pub enum Observer {
     #[default]
     Std1931,
@@ -84,7 +85,7 @@ pub enum Observer {
 
 #[cfg(feature = "supplemental-observers")]
 #[wasm_bindgen]
-#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug, EnumIter)]
 pub enum Observer {
     #[default]
     Std1931,

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -67,6 +67,10 @@ impl XYZ {
     /// optional white reference value yw.
     ///
     /// This produces a illuminant XYZ value, with xyz value set as xyzn.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CmtError::InvalidChromaticityValues` if the sum of x and y is greater than 1.0.
     pub fn from_chromaticity(
         x: f64,
         y: f64,
@@ -75,7 +79,7 @@ impl XYZ {
     ) -> Result<XYZ, CmtError> {
         let l = l.unwrap_or(100.0);
         let observer = observer.unwrap_or_default();
-        if (x + y) > 1.0 {
+        if (x + y) > 1.0 + f64::EPSILON {
             Err(CmtError::InvalidChromaticityValues)
         } else {
             let s = l / y;


### PR DESCRIPTION
This PR is very similar to #31. Caching computed results in a static attached to a type that have multiple variants cause the caching to store the value for the first variant it's called on, and then return that value for all subsequent method calls, even if it's called on a different observer. Again, correctness must be more important than performance.

I added `EnumIter` implementation for `Observer` to easily iterate over all observers. Other similar enums implement this, so I figured this one could as well. Makes the example easier to implement.

This PR also tries to fix #34.