### PR TITLE
Remove caching from `xyz2rgb` and `rgb2xyz` to fix bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Fix caching bug in `Observer::rgb2xyz` and `Observer::xyz2rgb`. If multiple observers are used,
+  only the computed matrixes for the first one to call into these methods would be returned in
+  subsequent invocations.
+
+
 ## [0.0.4] - 2025-05-06
 
 ### Added

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -168,7 +168,8 @@ impl RGB {
 impl Light for RGB {
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = &self.space.data().primaries;
-        let yrgb = self.observer.data().rgb2xyz(&self.space).row(1);
+        let rgb2xyz = self.observer.data().rgb2xyz(&self.space);
+        let yrgb = rgb2xyz.row(1);
         //        self.rgb.iter().zip(yrgb.iter()).zip(prim.iter()).map(|((v,w),s)|*v * *w * &s.0).sum()
         let s = self
             .rgb
@@ -199,7 +200,8 @@ impl Filter for RGB {
     */
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = self.space.data().primaries_as_colorants();
-        let yrgb = self.observer.data().rgb2xyz(&self.space).row(1);
+        let rgb2xyz = self.observer.data().rgb2xyz(&self.space);
+        let yrgb = rgb2xyz.row(1);
         let s = self
             .rgb
             .iter()

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -80,7 +80,8 @@ impl Sum for Stimulus {
 impl From<RGB> for Stimulus {
     fn from(rgb: RGB) -> Self {
         let prim = &rgb.space.data().primaries;
-        let yrgb = rgb.observer.data().rgb2xyz(&rgb.space).row(1);
+        let rgb2xyz = rgb.observer.data().rgb2xyz(&rgb.space);
+        let yrgb = rgb2xyz.row(1);
         rgb.rgb
             .iter()
             .zip(yrgb.iter())


### PR DESCRIPTION
The caching made the computed matrixes only valid for the first observer they were called on. This is the exact same problem as in #35 and #31. Statics can't be used to store values that depend on data in `self` when `self` can change between multiple calls to the same code.