### PR TITLE
Remove `Observer::xyz_cie_table` caching

### DIFF
--- a/src/cri.rs
+++ b/src/cri.rs
@@ -7,10 +7,7 @@
  */
 
 use nalgebra::{ArrayStorage, SMatrix};
-use std::{
-    ops::Index,
-    sync::{LazyLock, OnceLock},
-};
+use std::{ops::Index, sync::LazyLock};
 use wasm_bindgen::prelude::*;
 
 use crate::{

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -178,18 +178,12 @@ impl ObserverData {
     }
 
     /**
-        Tristimulus Values for the Standard Illuminants in this library.
+        Tristimulus values for the Standard Illuminants in this library.
 
-        Values are calculated on first use, and are not normalized by default, unless an illuminous
-        value is provided, in case they are.
+        Values are not normalized by default, unless an illuminance value is provided.
     */
     pub fn xyz_cie_table(&self, std_illuminant: &StdIlluminant, illuminance: Option<f64>) -> XYZ {
-        const XYZ_STD_ILLUMINANTS_LEN: usize = 64;
-        static XYZ_STD_ILLUMINANTS: [OnceLock<XYZ>; XYZ_STD_ILLUMINANTS_LEN] =
-            [const { OnceLock::new() }; XYZ_STD_ILLUMINANTS_LEN];
-
-        let xyz = *XYZ_STD_ILLUMINANTS[*std_illuminant as usize]
-            .get_or_init(|| self.xyz_from_spectrum(std_illuminant.illuminant(), None));
+        let xyz = self.xyz_from_spectrum(std_illuminant.illuminant(), None);
         if let Some(l) = illuminance {
             xyz.set_illuminance(l)
         } else {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -160,7 +160,7 @@ impl ObserverData {
 
     /**
         Calculates Tristimulus valus, in form of an [XYZ] object of a general spectrum.
-        If a reference white is given (rhs), it will copy its  tristimulus value, and the spectrum
+        If a reference white is given (rhs), it will copy its tristimulus value, and the spectrum
         is interpreted as a stimulus, being a combination of an illuminant with a colorant.
         If no reference white is given, the spectrum is interpreted as an illuminant.
         This method produces the raw XYZ data, not normalized to 100.0
@@ -407,7 +407,6 @@ impl ObserverData {
     }
 
     /// Calculates the RGB to XYZ matrix, for a particular color space.
-    /// The matrices are buffered.
     pub fn rgb2xyz(&self, rgbspace: &RgbSpace) -> Matrix3<f64> {
         let space = rgbspace.data();
         let mut rgb2xyz = Matrix3::from_iterator(space.primaries.iter().flat_map(|s| {
@@ -427,7 +426,6 @@ impl ObserverData {
     }
 
     /// Calculates the RGB to XYZ matrix, for a particular color space.
-    /// The matrices are buffered.
     pub fn xyz2rgb(&self, rgbspace: RgbSpace) -> Matrix3<f64> {
         // unwrap: only used with library color spaces
         self.rgb2xyz(&rgbspace).try_inverse().unwrap()

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use approx::AbsDiffEq;
 use nalgebra::{Matrix3, Vector3};
-use std::{borrow::Cow, sync::OnceLock};
+use std::borrow::Cow;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 /// Representation of a color stimulus in a set of Red, Green, and Blue (RGB) values,

--- a/src/rgbspace.rs
+++ b/src/rgbspace.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{LazyLock, OnceLock},
-};
+use std::{collections::HashMap, sync::OnceLock};
 
 use crate::{
     colorant::Colorant, data::illuminants::D65, data::observers::CIE1931, gamma::GammaCurve,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,9 +7,10 @@ use crate::{
 /**
 Spectral representation of Lights, typically in form of (standard) Illuminants.
 
-Also allows to use lookup tristimulus values, such as the very common [`D65`](crate::std_illuminants::StdIlluminant::D65) illuminant (see [`StdIlluminant`](crate::std_illuminants::StdIlluminant) implemention).
-Calculating them from a spectrum is the default implementation.  For standard illuminants,
-especially D65, which are used so frequently, their values are obtained from buffered entries.
+Also allows to use lookup tristimulus values, such as the very common
+[`D65`](crate::std_illuminants::StdIlluminant::D65) illuminant
+(see [`StdIlluminant`](crate::std_illuminants::StdIlluminant) implemention).
+Calculating them from a spectrum is the default implementation.
 */
 pub trait Light {
     /// Calculates the tristimulus values of the light source, using the


### PR DESCRIPTION
Same issue as #37 and friends.

This PR also updates some documentation around caching/buffering that was forgotten/outdated.

This PR also removes some unused imports that I'm not sure why rustc did not warn about :open_mouth: 