### PR TITLE
Add caching of spectral locus min/max and improve API of access to spectral locus and CMFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add `x()`, `y()` and `z()` methods to `XYZ` for easy access to each channel value.
 
 ### Changed
-- Constrained `Rgb` type to in-gamut values only, i.e. all R,G, and B values are required to be the
+- Constrain `Rgb` type to in-gamut values only, i.e. all R, G, and B values are required to be the
   range of [0..=1.0].
 - Renamed `RGB` type to `Rgb`
-- Change the return type of `Observer::spectral_locus_by_index` from `[f64; 2]` to
-  `Option<[f64; 2]>`. Allows returning `None` for invalid indices.
 - Stop normalizing XYZ values to illuminance = 100 in `XYZ::values()`.
+- Replace `spectral_locus_nm_min` and `spectral_locus_nm_max` with a single
+  `spectral_locus_wavelength_range` method that return both values as a typed range.
+- Rename `Observer::spectral_locus_by_nm` to `xyz_at_wavelength` and relax the constraints on
+  the allowed wavelength range. This method can now sample the color matching functions in the
+  full range from 380 - 780 nm.
+
+### Removed
+- Make `spectral_locus_index_min`, `spectral_locus_index_max` and `spectral_locus_by_index`
+  private.
 
 ### Fixed
 - Fix `CIE2015_10` data error (X and Y CMF's were identical)
@@ -47,10 +54,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Removed
   - Remove `RGB::from_xyz` method, which requires XYZ values to be in the range from 0.0 to 1.0;
     use `XYZ::rgb` instead, as that uses the reference illuminance for scaling.
-
-### Fixed
-  - Fix bug in RgbSpaceData::primaries_as_colorants by removing caching
-
 
 
 ## [0.0.4] - 2025-05-06

--- a/examples/spectral_locus.rs
+++ b/examples/spectral_locus.rs
@@ -5,15 +5,18 @@ use strum::IntoEnumIterator;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     for observer in Observer::iter() {
-        let nm_min = observer.data().spectral_locus_nm_min();
-        let nm_max = observer.data().spectral_locus_nm_max();
-        println!("Spectral locus for {observer:?} goes from {nm_min} to {nm_max}:");
+        let wavelength_range = observer.data().spectral_locus_wavelength_range();
+        println!(
+            "Spectral locus for {observer:?} goes from {} to {}",
+            wavelength_range.start(),
+            wavelength_range.end()
+        );
         println!("nm\tx\t y");
-        for nm in nm_min..=nm_max {
+        for wavelength in wavelength_range {
             // unwrap OK because nm is in range
-            let xyz = observer.data().spectral_locus_by_nm(nm).unwrap();
+            let xyz = observer.data().xyz_at_wavelength(wavelength).unwrap();
             let [x, y] = xyz.chromaticity();
-            println!("{nm}\t{x:.4}\t{y:.4}");
+            println!("{wavelength}\t{x:.4}\t{y:.4}");
         }
         println!("==========================");
     }

--- a/src/data/observers.rs
+++ b/src/data/observers.rs
@@ -6,10 +6,10 @@ use crate::{
     spectrum::{Spectrum, NS},
 };
 
-pub static CIE1931: ObserverData = ObserverData {
-    tag: Observer::Std1931,
-    lumconst: 683.0,
-    data: SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
+pub static CIE1931: ObserverData = ObserverData::new(
+    Observer::Std1931,
+    683.0,
+    SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.001368, 0.000039, 0.006450001],
         [0.00150205, 0.0000428264, 0.007083216],
         [0.001642328, 0.0000469146, 0.007745488],
@@ -412,13 +412,13 @@ pub static CIE1931: ObserverData = ObserverData {
         [0.00004448567, 0.00001606459, 0.0],
         [0.00004150994, 0.00001499, 0.0],
     ])),
-};
+);
 
 #[cfg(feature = "supplemental-observers")]
-pub static CIE1964: ObserverData = ObserverData {
-    tag: Observer::Std1964,
-    lumconst: 683.0,
-    data: SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
+pub static CIE1964: ObserverData = ObserverData::new(
+    Observer::Std1964,
+    683.0,
+    SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.000159952, 0.000017364, 0.000704776],
         [0.00021508, 0.000023327, 0.00094823],
         [0.00028749, 0.00003115, 0.0012682],
@@ -821,13 +821,13 @@ pub static CIE1964: ObserverData = ObserverData {
         [0.000035657, 0.0000141336, 0.0],
         [0.0000334117, 0.000013249, 0.0],
     ])),
-};
+);
 
 #[cfg(feature = "supplemental-observers")]
-pub static CIE2015: ObserverData = ObserverData {
-    tag: Observer::Std2015,
-    lumconst: 683.0,
-    data: SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
+pub static CIE2015: ObserverData = ObserverData::new(
+    Observer::Std2015,
+    683.0,
+    SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.0, 0.0, 0.0],
         [0.0, 0.0, 0.0],
         [0.0, 0.0, 0.0],
@@ -1230,7 +1230,7 @@ pub static CIE2015: ObserverData = ObserverData {
         [0.00004058715, 0.00001585309, 0.0],
         [0.00003806114, 0.00001487243, 0.0],
     ])),
-};
+);
 
 #[cfg(feature = "supplemental-observers")]
 /// CIE 2015 10° Observer Data
@@ -1256,10 +1256,10 @@ pub static CIE2015: ObserverData = ObserverData {
 /// This dataset is intended for spectral color calculations involving wider visual fields and is especially
 /// relevant for applications in display technology, lighting design, and colorimetry where larger visual fields
 /// are encountered.
-pub static CIE2015_10: ObserverData = ObserverData {
-    tag: Observer::Std2015_10,
-    lumconst: 683.0,
-    data: SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
+pub static CIE2015_10: ObserverData = ObserverData::new(
+    Observer::Std2015_10,
+    683.0,
+    SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.000000E+00, 0.000000E+00, 0.000000E+00],
         [0.000000E+00, 0.000000E+00, 0.000000E+00],
         [0.000000E+00, 0.000000E+00, 0.000000E+00],
@@ -1662,4 +1662,4 @@ pub static CIE2015_10: ObserverData = ObserverData {
         [3.633762E-05, 1.426169E-05, 0.000000E+00],
         [3.407653E-05, 1.337946E-05, 0.000000E+00],
     ])),
-};
+);

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,8 +28,6 @@ pub enum CmtError {
     NoIntersection,
     #[error("Wavelength out of range")]
     WavelengthOutOfRange,
-    #[error("Allowed wavelength range for this function is {0} to {1} nanometer")]
-    NoUniqueSpectralLocus(usize, usize),
     #[error("Invalid Chromaticity Values")]
     InvalidChromaticityValues,
     #[error("This Method Requires CIE 1931-based XYZ values")]

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -63,6 +63,7 @@ use crate::{
 use nalgebra::{Matrix3, SMatrix, Vector3};
 use std::{
     borrow::{Borrow, Cow},
+    ops::{Index, RangeInclusive},
     sync::OnceLock,
 };
 use strum_macros::EnumIter;
@@ -135,9 +136,27 @@ pub struct ObserverData {
     pub(crate) data: SMatrix<f64, 3, NS>,
     pub(crate) lumconst: f64,
     pub(crate) tag: Observer,
+
+    /// The range of indices for which the spectral locus of this observer returns unique
+    /// chromaticity coordinates. See documentation for the
+    /// [`ObserverData::spectral_locus_wavelength_range`] method for details.
+    spectral_locus_range: OnceLock<RangeInclusive<usize>>,
 }
 
 impl ObserverData {
+    /// Creates a new `ObserverData` object, with the given color matching functions.
+    ///
+    /// Only visible to the crate itself since it cannot be used nicely from the outside
+    /// (since the `tag` is not something anyone else can create new varians of).
+    pub(crate) const fn new(tag: Observer, lumconst: f64, data: SMatrix<f64, 3, NS>) -> Self {
+        Self {
+            data,
+            lumconst,
+            tag,
+            spectral_locus_range: OnceLock::new(),
+        }
+    }
+
     /// Calulates Tristimulus values for an object implementing the [Light] trait, and an optional [Filter],
     /// filtering the light.
     ///
@@ -176,6 +195,24 @@ impl ObserverData {
             // illuminant only
             XYZ::from_vecs(xyz, None, self.tag)
         }
+    }
+
+    /// Returns the observer's color matching function (CMF) data as an [XYZ] tristimulus
+    /// value for the given wavelength.
+    ///
+    /// This allows access to the underlying data for the entire range of wavelengths, 380-780nm.
+    /// However, please read the documentation for the
+    /// [`spectral_locus_wavelength_range`](Self::spectral_locus_wavelength_range) method on
+    /// situations where you might not want to sample the full range.
+    pub fn xyz_at_wavelength(&self, wavelength: usize) -> Result<XYZ, CmtError> {
+        if !SPECTRUM_WAVELENGTH_RANGE.contains(&wavelength) {
+            return Err(CmtError::WavelengthOutOfRange);
+        };
+        let &[x, y, z] = self
+            .data
+            .column(wavelength - SPECTRUM_WAVELENGTH_RANGE.start())
+            .as_ref();
+        Ok(XYZ::from_vecs(Vector3::new(x, y, z), None, self.tag))
     }
 
     /**
@@ -307,107 +344,35 @@ impl ObserverData {
         xyz0.try_into().unwrap()
     }
 
-    /// Calculate the Spectral Locus, or (x,y) coordinates of the _horse shoe_,
-    /// the boundary of area of all physical colors in a chromiticity diagram,
-    /// as XYZ tristimulus values.  Tristimulus values are returned here,
-    /// instead of chromaticity xy coordinates, to make use of the available XYZ
-    /// transforms.
+    /// Returns the wavelength range (in nanometer) for the _horse shoe_,
+    /// the boundary of the area of all physical colors in a chromiticity diagram,
+    /// for this observer.
     ///
-    /// This function limits the input values to produce unique chromaticity
-    /// values only.  Spectral locus points tend to freeze, or even fold back to
-    /// lower wavelength values at the blue and red perimeter ends.  This can be
-    /// quite anoying, for example when trying to calculate dominant wavelength,
-    /// or when creating plots.  To get the allowed range, use the
-    /// `spectral_wavelength_min` and `spectral_wavelength_max` methods.
-    ///
+    /// Spectral locus points tend to freeze, or even fold back to lower wavelength
+    /// values at the blue and red perimeter ends. This can be quite anoying, for
+    /// example when trying to calculate dominant wavelength, or when creating
+    /// plots.
     /// See Wikipedia's [CIE 1931 Color Space](https://en.wikipedia.org/wiki/CIE_1931_color_space).
-    pub fn spectral_locus_by_nm(&self, l: usize) -> Result<XYZ, CmtError> {
-        let min = self.spectral_locus_nm_min();
-        let max = self.spectral_locus_nm_max();
-        if !SPECTRUM_WAVELENGTH_RANGE.contains(&l) {
-            return Err(CmtError::WavelengthOutOfRange);
-        };
-        if l < min || l > max {
-            Err(CmtError::NoUniqueSpectralLocus(min, max))
-        } else {
-            let &[x, y, z] = self.data.column(l - 380).as_ref();
-            Ok(XYZ::from_vecs(Vector3::new(x, y, z), None, self.tag))
-        }
-    }
-
-    /// Unrestricted, direct, access to the spectal locus data, in the form of
-    /// chromaticity coordinates.
     ///
-    /// To get unique values only please use the `spectral_locus_by_nm` function.
+    /// To help with the above problem, this method returns the wavelength range
+    /// for which the spectral locus points are unique, meaning
+    /// each wavelength has a chromaticity coordinate different from the wavelength
+    /// below or above it.
     ///
-    /// This method returns `None` for indices outside the valid range returned by
-    /// [`Self::spectral_locus_index_min`] and [`Self::spectral_locus_index_max`].
-    pub fn spectral_locus_by_index(&self, i: usize) -> Option<[f64; 2]> {
-        let &[x, y, z] = self.data.get((.., i))?.as_ref();
-        let s = x + y + z;
-        if s != 0.0 {
-            Some([x / s, y / s])
-        } else {
-            None
-        }
-    }
-
-    /// The index value of the blue spectral locus edge.
+    /// To get the tristimulus values of the spectral locus, use
+    /// [`xyz_at_wavelength`](Self::xyz_at_wavelength).
     ///
-    /// Any further spectral locus points will hover around this edge, and will not have a unique wavelength.
-    pub fn spectral_locus_index_min(&self) -> usize {
-        const START: usize = 100;
-        let spectral_locus_pos_start = self.spectral_locus_by_index(START).unwrap();
-        let mut lp = LineAB::new(spectral_locus_pos_start, [0.33333, 0.33333]).unwrap();
-        let mut m = START - 1;
-        loop {
-            let Some(spectral_locus_pos_m) = self.spectral_locus_by_index(m) else {
-                break m + 1;
-            };
-            let l = LineAB::new(spectral_locus_pos_m, [0.33333, 0.33333]).unwrap();
-            match (m, l.angle_diff(lp)) {
-                (0, d) if d > -f64::EPSILON => break m + 1,
-                (0, _) => break 0,
-                (1.., d) if d > -f64::EPSILON => break m,
-                _ => {
-                    m -= 1;
-                    lp = l;
-                }
-            }
-        }
-    }
-
-    pub fn spectral_locus_nm_min(&self) -> usize {
-        self.spectral_locus_index_min() + 380
-    }
-
-    /// The index value of the red spectral locus edge.
-    ///
-    /// Any further spectral locus points will hover around this edge.
-    pub fn spectral_locus_index_max(&self) -> usize {
-        const START: usize = 300;
-        let spectral_locus_pos_start = self.spectral_locus_by_index(START).unwrap();
-        let mut lp = LineAB::new(spectral_locus_pos_start, [0.33333, 0.33333]).unwrap();
-        let mut m = START + 1;
-        loop {
-            let Some(spectral_locus_pos_m) = self.spectral_locus_by_index(m) else {
-                break m + 1;
-            };
-            let l = LineAB::new(spectral_locus_pos_m, [0.33333, 0.33333]).unwrap();
-            match (m, l.angle_diff(lp)) {
-                (400, d) if d < f64::EPSILON => break m - 1,
-                (400, _) => break 400,
-                (..400, d) if d < f64::EPSILON => break m - 1,
-                _ => {
-                    m += 1;
-                    lp = l;
-                }
-            }
-        }
-    }
-
-    pub fn spectral_locus_nm_max(&self) -> usize {
-        self.spectral_locus_index_max() + 380
+    /// This range is computed on first access and then buffered for quick future access.
+    pub fn spectral_locus_wavelength_range(&self) -> RangeInclusive<usize> {
+        self.spectral_locus_range
+            .get_or_init(|| {
+                let min = self.spectral_locus_index_min() + *SPECTRUM_WAVELENGTH_RANGE.start();
+                let max = self.spectral_locus_index_max() + *SPECTRUM_WAVELENGTH_RANGE.start();
+                debug_assert!(min >= *SPECTRUM_WAVELENGTH_RANGE.start());
+                debug_assert!(max <= *SPECTRUM_WAVELENGTH_RANGE.end());
+                min..=max
+            })
+            .clone()
     }
 
     /// Calculates the RGB to XYZ matrix, for a particular color space.
@@ -433,6 +398,68 @@ impl ObserverData {
         // unwrap: only used with library color spaces
         self.rgb2xyz(&rgbspace).try_inverse().unwrap()
     }
+
+    /// The index value of the blue spectral locus edge.
+    ///
+    /// Any further spectral locus points will hover around this edge, and will not have a unique wavelength.
+    fn spectral_locus_index_min(&self) -> usize {
+        const START: usize = 100;
+        let spectral_locus_pos_start = self.spectral_locus_by_index(START).unwrap();
+        let mut lp = LineAB::new(spectral_locus_pos_start, [0.33333, 0.33333]).unwrap();
+        let mut m = START - 1;
+        loop {
+            let Some(spectral_locus_pos_m) = self.spectral_locus_by_index(m) else {
+                break m + 1;
+            };
+            let l = LineAB::new(spectral_locus_pos_m, [0.33333, 0.33333]).unwrap();
+            match (m, l.angle_diff(lp)) {
+                (0, d) if d > -f64::EPSILON => break m + 1,
+                (0, _) => break 0,
+                (1.., d) if d > -f64::EPSILON => break m,
+                _ => {
+                    m -= 1;
+                    lp = l;
+                }
+            }
+        }
+    }
+
+    /// The index value of the red spectral locus edge.
+    ///
+    /// Any further spectral locus points will hover around this edge.
+    fn spectral_locus_index_max(&self) -> usize {
+        const START: usize = 300;
+        let spectral_locus_pos_start = self.spectral_locus_by_index(START).unwrap();
+        let mut lp = LineAB::new(spectral_locus_pos_start, [0.33333, 0.33333]).unwrap();
+        let mut m = START + 1;
+        loop {
+            let Some(spectral_locus_pos_m) = self.spectral_locus_by_index(m) else {
+                break m + 1;
+            };
+            let l = LineAB::new(spectral_locus_pos_m, [0.33333, 0.33333]).unwrap();
+            match (m, l.angle_diff(lp)) {
+                (400, d) if d < f64::EPSILON => break m - 1,
+                (400, _) => break 400,
+                (..400, d) if d < f64::EPSILON => break m - 1,
+                _ => {
+                    m += 1;
+                    lp = l;
+                }
+            }
+        }
+    }
+
+    /// Unrestricted, direct, access to the spectal locus data, in the form of
+    /// chromaticity coordinates.
+    fn spectral_locus_by_index(&self, i: usize) -> Option<[f64; 2]> {
+        let &[x, y, z] = self.data.get((.., i))?.as_ref();
+        let s = x + y + z;
+        if s != 0.0 {
+            Some([x / s, y / s])
+        } else {
+            None
+        }
+    }
 }
 
 // JS-WASM Interface code
@@ -453,15 +480,16 @@ mod obs_test {
 
     #[test]
     fn test_cie1931_spectral_locus_min_max() {
+        let wavelength_lange = CIE1931.spectral_locus_wavelength_range();
         let [x, y] = CIE1931
-            .spectral_locus_by_nm(CIE1931.spectral_locus_nm_min())
+            .xyz_at_wavelength(*wavelength_lange.start())
             .unwrap()
             .chromaticity();
         assert_ulps_eq!(x, 0.17411, epsilon = 1E-5);
         assert_ulps_eq!(y, 0.00496, epsilon = 1E-5);
 
         let [x, y] = CIE1931
-            .spectral_locus_by_nm(CIE1931.spectral_locus_nm_max())
+            .xyz_at_wavelength(*wavelength_lange.end())
             .unwrap()
             .chromaticity();
         assert_ulps_eq!(x, 0.73469, epsilon = 1E-5);
@@ -472,17 +500,16 @@ mod obs_test {
     #[test]
     fn test_spectral_locus_full() {
         for observer in Observer::iter() {
-            let nm_min = observer.data().spectral_locus_nm_min();
-            let nm_max = observer.data().spectral_locus_nm_max();
+            let wavelength_range = observer.data().spectral_locus_wavelength_range();
 
-            // Basic sanity checking of the min/max values
-            assert!(nm_min >= *SPECTRUM_WAVELENGTH_RANGE.start());
-            assert!(nm_max <= *SPECTRUM_WAVELENGTH_RANGE.end());
-            assert!(nm_min < nm_max);
+            // Basic sanity checking of the spectral locus wavelength range values
+            assert!(wavelength_range.start() >= SPECTRUM_WAVELENGTH_RANGE.start());
+            assert!(wavelength_range.end() <= SPECTRUM_WAVELENGTH_RANGE.end());
+            assert!(wavelength_range.start() < wavelength_range.end());
 
-            // Check that spectral_locus_by_nm returns sane values in the allowed range
-            for nm in nm_min..=nm_max {
-                let xyz = observer.data().spectral_locus_by_nm(nm).unwrap();
+            // Check that xyz_at_wavelength returns sane values in the allowed range
+            for wavelength in wavelength_range {
+                let xyz = observer.data().xyz_at_wavelength(wavelength).unwrap();
                 let [x, y] = xyz.chromaticity();
                 assert!((0.0..=1.0).contains(&x));
                 assert!((0.0..=1.0).contains(&y));
@@ -499,12 +526,8 @@ mod obs_test {
     fn test_spectral_locus_to_rgb() {
         for observer in Observer::iter() {
             eprintln!("Testing observer {:?}", observer);
-            let nm_min = observer.data().spectral_locus_nm_min();
-            let nm_max = observer.data().spectral_locus_nm_max();
-
-            for nm in nm_min..=nm_max {
-                let xyz = observer.data().spectral_locus_by_nm(nm).unwrap();
-
+            for wavelength in observer.data().spectral_locus_wavelength_range() {
+                let xyz = observer.data().xyz_at_wavelength(wavelength).unwrap();
                 for rgbspace in RgbSpace::iter() {
                     let rgb = xyz.rgb(Some(rgbspace));
                 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -335,13 +335,15 @@ impl ObserverData {
         }
     }
 
-    /// Unrestricted, direct, access to the spectal locus data.
+    /// Unrestricted, direct, access to the spectal locus data, in the form of
+    /// chromaticity coordinates.
+    ///
     /// To get unique values only please use the `spectral_locus_by_nm` function.
     ///
-    /// This method returns `None` for indices that don't have a valid spectral locus
-    /// position.
+    /// This method returns `None` for indices outside the valid range returned by
+    /// [`Self::spectral_locus_index_min`] and [`Self::spectral_locus_index_max`].
     pub fn spectral_locus_by_index(&self, i: usize) -> Option<[f64; 2]> {
-        let &[x, y, z] = self.data.column(i).as_ref();
+        let &[x, y, z] = self.data.get((.., i))?.as_ref();
         let s = x + y + z;
         if s != 0.0 {
             Some([x / s, y / s])


### PR DESCRIPTION
My main aim with this change was to add back correct and fast caching of the computation of the lower and upper wavelength limits of the spectral locus. However, there were a few other things about the API of the `ObserverData` regarding the access of spectral locus values as well that has been an itch for me when learning and using this library. So I checked if I could improve on it in ways that I would find easy to understand and ergonomical to use. I hope you'll like it and that we can find some nice improved API that we both like :blush: 

Sadly it all went into one pretty big commit. It was really hard to make one change without making the others. But I'll explain each change here:

* Make `spectral_locus_index_min`, `spectral_locus_index_max` and `spectral_locus_by_index` private. Was there any use case I was not aware of that could prove these useful to a library consumer? To me it just felt confusing to expose this functionality both in the form of by-wavelength and by-index. The API surface became large, and these methods felt like internal implementation details. I moved them to the end of the `impl` body, since it's customary to keep public methods at the top where they are easier to find.
* Replace `spectral_locus_nm_min` and `spectral_locus_nm_max` with a single `spectral_locus_wavelength_range` that return both values as a typed range. It felt both more idiomatic and ergonomical to me to use the existing standard library type for expressing ranges. In almost all places this was used, it was used as `nm_min..=nm_max` anyway, so just passing the single range is simpler.
* Introduce caching of the spectral locus wavelength range back into the library! :tada: 
* Rename `spectral_locus_by_nm` to `xyz_at_wavelength` and relax the constraints on the allowed wavelength range. I think this new name fits better together with the sibling methods `xyz_from_spectrum` and others. I also did not see the need to limit the allowed wavelength. With good enough documentation the user will still be able to use it correctly. This allows sampling the entire range of the color matching functions. This data was previously hidden in this library and I wanted to find some way to expose it for users with special needs (for example rendering the full color matching functions as a graph)

I'm excited to hear what you think about these changes. If needed we can make adjustments and adopt only a subset of the changes.