### PR TITLE
Add ergonomic value getters to `XYZ` and `RGB`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Implement strums `EnumIter` on `Observer`. Allows easy iteration over all available observers.
+- Add `r()`, `g()` and `b()` methods to `RGB` for easy access to each channel value.
 
 ### Changed
 - Change the return type of `Observer::spectral_locus_by_index` from `[f64; 2]` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Change the return type of `Observer::spectral_locus_by_index` from `[f64; 2]` to
   `Option<[f64; 2]>`. Allows returning `None` for invalid indices.
+- Stop normalizing XYZ values to illuminance = 100 in `XYZ::values()`.
 
 ### Fixed
 - Fix caching bug in `Observer::spectral_locus_index_min` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Implement strums `EnumIter` on `Observer`. Allows easy iteration over all available observers.
 - Add `r()`, `g()` and `b()` methods to `RGB` for easy access to each channel value.
+- Add `x()`, `y()` and `z()` methods to `XYZ` for easy access to each channel value.
 
 ### Changed
 - Change the return type of `Observer::spectral_locus_by_index` from `[f64; 2]` to

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The easiest way to use the objects and functions in this library is through its 
     use colorimetry::prelude::*;
 
     // D65 Tristimulus values, using the CIE1931 standard observer by default
-    let [x, y, z] = D65.xyz(None).values();
+    let [x, y, z] = D65.xyz(None).set_illuminance(100.0).values();
 
     approx::assert_ulps_eq!(x, 95.04, epsilon = 5E-3);
     approx::assert_ulps_eq!(y, 100.0, epsilon = 5E-3);

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -102,6 +102,21 @@ impl RGB {
         RGB::new(r, g, b, Some(xyz.observer), Some(space))
     }
 
+    /// Returns the value of the red channel.
+    pub fn r(&self) -> f64 {
+        self.rgb.x
+    }
+
+    /// Returns the value of the green channel.
+    pub fn g(&self) -> f64 {
+        self.rgb.y
+    }
+
+    /// Returns the value of the blue channel.
+    pub fn b(&self) -> f64 {
+        self.rgb.z
+    }
+
     /// Returns the RGB values as an array with the red, green, and blue values respectively
     ///
     /// ```rust

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -710,7 +710,7 @@ mod tests {
 
     #[test]
     fn d65_test() {
-        let [x, y, z] = D65.xyz(None).values();
+        let [x, y, z] = D65.xyz(None).set_illuminance(100.0).values();
         assert_ulps_eq!(x, 95.04, epsilon = 5E-3);
         assert_ulps_eq!(y, 100.0, epsilon = 5E-3);
         assert_ulps_eq!(z, 108.86, epsilon = 5E-3);

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -161,10 +161,7 @@ impl XYZ {
     /// assert_ulps_eq!(z, 108.861_036, epsilon = 1E-6);
     /// ```
     pub fn values(&self) -> [f64; 3] {
-        let xyz_matrix = self.xyz.unwrap_or(self.xyzn);
-        let s = 100.0 / self.xyzn.y;
-        let xyz_array: [f64; 3] = *xyz_matrix.as_ref();
-        xyz_array.map(|v| v * s)
+        *self.xyz.unwrap_or(self.xyzn).as_ref()
     }
 
     /// Set the illuminance of an illuminant, either for an illuminant directly,

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -115,6 +115,39 @@ impl XYZ {
         }
     }
 
+    /// Returns the X value.
+    /// ```
+    /// use colorimetry::{xyz::XYZ, observer::Observer};
+    ///
+    /// let xyz = XYZ::new([95.1, 95.0, 27.0], None, Observer::Std1931);
+    /// assert_eq!(xyz.x(), 95.1);
+    /// ```
+    pub fn x(&self) -> f64 {
+        self.values()[0]
+    }
+
+    /// Returns the Y value.
+    /// ```
+    /// use colorimetry::{xyz::XYZ, observer::Observer};
+    ///
+    /// let xyz = XYZ::new([95.1, 95.0, 27.0], None, Observer::Std1931);
+    /// assert_eq!(xyz.y(), 95.0);
+    /// ```
+    pub fn y(&self) -> f64 {
+        self.values()[1]
+    }
+
+    /// Returns the Z value.
+    /// ```
+    /// use colorimetry::{xyz::XYZ, observer::Observer};
+    ///
+    /// let xyz = XYZ::new([95.1, 95.0, 27.0], None, Observer::Std1931);
+    /// assert_eq!(xyz.z(), 27.0);
+    /// ```
+    pub fn z(&self) -> f64 {
+        self.values()[2]
+    }
+
     /// XYZ Tristimulus values in an an array: [X, Y, Z]
     /// ```
     /// use colorimetry::prelude::*;

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -121,7 +121,7 @@ impl XYZ {
     /// use approx::assert_ulps_eq;
     ///
     /// let d65_xyz = CIE1931.xyz(&StdIlluminant::D65, None).set_illuminance(100.0);
-    /// let [x, y, z] = d65_xyz.into();
+    /// let [x, y, z] = d65_xyz.values();
     /// // Calculated Spreadsheet Values from CIE Datasets, over a range from 380 to 780nm
     /// assert_ulps_eq!(x, 95.042_267, epsilon = 1E-6);
     /// assert_ulps_eq!(y, 100.0);


### PR DESCRIPTION
I find myself quite often writing code like:
```rust
let xyz = compute_tristimulus_values(...);
let [x, y, z] = xyz.values();
// Do something with the values
```
And the equivalent for RGB. Needing a completely separate statement and three extra variables just to get access to the raw values is proving a bit inconvenient for me. So I wanted to suggest the addition of these very simple getters.

I found it surprising that `XYZ::values()` does not just return the raw values untouched, but rather normalize them. That does not seem optimal for a simple getter. If a user fetch the values with `values()` and check something on them, and then use the `XYZ` instance for something else, they might not be aware that the values they are using are not the same ones they inspected earlier. I think not touching the values in this straight forward getter leaves more power and flexibility to the user. They can still get back the old behavior by just slapping a `.set_illuminance(100.0)` wherever they previously just used `values()`, if they want the values normalized to illuminance 100. What do you think about this?