### PR TITLE
Remove `impl From<WideRgb> for [u8; 3]` in favor of being more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Remove undocumented `XYZ::srgb` method that both clamped out-of-gamut values and converted
   directly to a gamma encoded `[u8; 3]`. Obtain the same result with the more explicit
   `xyz.rgb(Some(RgbSpace::SRGB)).clamp().values()`.
+- Remove conversion directly from `WideRgb` to clamped and gamma encoded `[u8; 3]`. Prefer being
+  more explicit by converting to the `Rgb` type in between with one of the provided conversion
+  methods.
 
 
 ## [0.0.5] - 2025-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Removed
+- Remove undocumented `XYZ::srgb` method that both clamped out-of-gamut values and converted
+  directly to a gamma encoded `[u8; 3]`. Obtain the same result with the more explicit
+  `xyz.rgb(Some(RgbSpace::SRGB)).clamp().values()`.
+
+
 ## [0.0.5] - 2025-05-14
 
 ### Added

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -35,7 +35,7 @@ pub static TCS: LazyLock<[Colorant; N_TCS]> = LazyLock::new(|| {
 fn tcs_test() {
     for (i, s) in TCS.iter().enumerate() {
         let xyz = CIE1931.xyz(&crate::std_illuminants::StdIlluminant::D65, Some(s));
-        let [r, g, b] = xyz.srgb();
+        let [r, g, b] = xyz.rgb(Some(RgbSpace::SRGB)).values();
         println!("{:2} ({r:3},{g:3},{b:3})", i + 1);
     }
 

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -255,14 +255,14 @@ impl ObserverData {
         and converting the resulting value to RGB values.
         ```
             use colorimetry::prelude::*;
-            let rgb: [u8;3] = CIE1931.xyz_from_std_illuminant_x_fn(&StdIlluminant::D65, |x|x).rgb(None).into();
+            let rgb: [u8;3] = CIE1931.xyz_from_std_illuminant_x_fn(&StdIlluminant::D65, |x|x).rgb(None).clamp().into();
             assert_eq!(rgb, [212, 171, 109]);
         ```
         Linear low pass filter, with a value of 1.0 for a wavelength of 380nm, and a value of 0.0 for 780nm,
         and converting the resulting value to RGB values.
         ```
             use colorimetry::prelude::*;
-            let rgb: [u8;3] = CIE1931.xyz_from_std_illuminant_x_fn(&StdIlluminant::D65, |x|1.0-x).rgb(None).into();
+            let rgb: [u8;3] = CIE1931.xyz_from_std_illuminant_x_fn(&StdIlluminant::D65, |x|1.0-x).rgb(None).clamp().into();
             assert_eq!(rgb, [158, 202, 237]);
         ```
 

--- a/src/widergb.rs
+++ b/src/widergb.rs
@@ -132,8 +132,20 @@ impl WideRgb {
 
     /// Converts a `WideRgb` value to a valid `Rgb` value by clamping red, green, and blue values to the range [0, 1].
     ///
+    /// ```rust
+    /// # use colorimetry::widergb::WideRgb;
+    ///
+    /// // A `WideRgb` value with out-of-gamut components.
+    /// let wide_rgb = WideRgb::new(1.2, -0.5, 0.8, None, None);
+    ///
+    /// // Clamp the values to the [0.0, 1.0] range.
+    /// let clamped_rgb = wide_rgb.clamp();
+    ///
+    /// assert_eq!(clamped_rgb.values(), [1.0, 0.0, 0.8]);
+    /// ```
+    ///
     /// # Parameters
-    /// - `self`: The `WideRgb` instance to be compressed.
+    /// - `self`: The `WideRgb` instance to be clamped.
     ///
     /// # Returns
     /// A new `Rgb` instance with the adjusted RGB values, ensuring they are within the allowable range.

--- a/src/widergb.rs
+++ b/src/widergb.rs
@@ -14,8 +14,7 @@
 //!   CIE 2015), enhancing accuracy in color conversions and comparisons.
 //! - **Conversion Methods:** Provides methods to clamp, compress, and convert `WideRgb` values to
 //!   standard `Rgb` values within the `[0.0, 1.0]` range.
-//! - **Compatibility:** Includes conversions to `XYZ` tristimulus values, standard `Rgb`, and
-//!   `u8` arrays for 8-bit encoded RGB values.
+//! - **Compatibility:** Includes conversions to `XYZ` tristimulus values and standard `Rgb`.
 //!
 //! ## Example Usage
 //!
@@ -219,14 +218,6 @@ impl AsRef<Vector3<f64>> for WideRgb {
     }
 }
 
-/// Clamped RGB values as a u8 array. Uses gamma function.
-impl From<WideRgb> for [u8; 3] {
-    fn from(rgb: WideRgb) -> Self {
-        let data: &[f64; 3] = rgb.rgb.as_ref();
-        data.map(|v| (rgb.space.data().gamma.encode(v.clamp(0.0, 1.0)) * 255.0).round() as u8)
-    }
-}
-
 impl From<WideRgb> for [f64; 3] {
     fn from(rgb: WideRgb) -> Self {
         rgb.values()
@@ -260,7 +251,7 @@ mod rgb_tests {
     use crate::prelude::*;
 
     #[test]
-    fn get_values_f64() {
+    fn get_values() {
         let rgb = WideRgb::new(0.1, 0.2, 0.3, None, None);
         let [r, g, b] = <[f64; 3]>::from(rgb);
         assert_eq!(r, 0.1);
@@ -269,11 +260,11 @@ mod rgb_tests {
     }
 
     #[test]
-    fn get_values_u8() {
-        let rgb = WideRgb::new(0.1, 0.2, 0.3, None, None);
-        let [r, g, b] = <[u8; 3]>::from(rgb);
-        assert_eq!(r, 89);
-        assert_eq!(g, 124);
-        assert_eq!(b, 149);
+    fn out_of_gamut_values() {
+        let rgb = WideRgb::new(-0.8, 2.7, 0.8, None, None);
+        let [r, g, b] = rgb.values();
+        assert_eq!(r, -0.8);
+        assert_eq!(g, 2.7);
+        assert_eq!(b, 0.8);
     }
 }

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -393,10 +393,6 @@ impl XYZ {
             rgb: data,
         }
     }
-
-    pub fn srgb(&self) -> [u8; 3] {
-        self.rgb(None).into()
-    }
 }
 
 /*


### PR DESCRIPTION
When I in some previous PRs and issues argued for splitting some types up into multiple types, and enforcing constraints on their values harder, it was to have the compiler help the user catch issues. And for the code to spell out what happens better when using the library. This includes not automagically converting between types where the user probably want to make a choice about how the conversion happens, and not automagically converting multiple steps in one go etc.

Instead I think that providing good documentation about what the user needs to do to convert between types to achieve their desired behavior, and providing logical, well named, one-step-at-a-time conversion methods, helps the user much more. We mostly have these well documented steps available! And that's awesome :partying_face: It's just that we *also* have slightly vague, underdocumented, semi-magical conversion code that can confuse the user.

I might be wrong, but I think that just clamping a `WideRgb` to get an `Rgb` value is not what most users want or expect. If using a `WideRgb` where an in-gamut-rgb is needed and no compiler errors happens, the user will likely just end up with unwanted colors and not understand why. But if they get a compiler error, go to the docs and see that they need to tell the library how they want their out-of-gamut values transformed to in-gamut values, then they will probably learn faster and have hard-to-debug issues less often.

This PR does not remove any real functionality from the library. It just forces the user to be a little bit more explicit with how they want their RGB values converted :sparkles: 