### PR TITLE
Use existing `SPECTRUM_WAVELENGTH_RANGE` instead of repeating the `380`/`780` integer literals

### DIFF
--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -10,7 +10,7 @@ use crate::{
     error::CmtError,
     lab::CieLab,
     physics::{gaussian_peak_one, wavelength},
-    prelude::{Illuminant, Observer, D65},
+    prelude::{Illuminant, Observer, D65, SPECTRUM_WAVELENGTH_RANGE},
     spectrum::{wavelengths, Spectrum, NS},
     std_illuminants,
     traits::{Filter, Light},
@@ -96,8 +96,7 @@ impl Colorant {
         let left = center_m - width_m / 2.0;
         let right = center_m + width_m / 2.0;
         let data = SVector::<f64, NS>::from_fn(|i, _j| {
-            //  let w = (i+380) as f64 * 1E-9;
-            let w = wavelength(i + 380);
+            let w = wavelength(i + SPECTRUM_WAVELENGTH_RANGE.start());
             if w < left - f64::EPSILON || w > right + f64::EPSILON {
                 0.0
             } else {
@@ -114,7 +113,11 @@ impl Colorant {
     pub fn gaussian(center: f64, sigma: f64) -> Self {
         let [center_m, width_m] = wavelengths([center, sigma]);
         let data = SVector::<f64, NS>::from_fn(|i, _j| {
-            gaussian_peak_one((i + 380) as f64 * 1E-9, center_m, width_m)
+            gaussian_peak_one(
+                (i + SPECTRUM_WAVELENGTH_RANGE.start()) as f64 * 1E-9,
+                center_m,
+                width_m,
+            )
         });
         Self(Spectrum(data))
     }

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -114,7 +114,7 @@ impl Colorant {
         let [center_m, width_m] = wavelengths([center, sigma]);
         let data = SVector::<f64, NS>::from_fn(|i, _j| {
             gaussian_peak_one(
-                (i + SPECTRUM_WAVELENGTH_RANGE.start()) as f64 * 1E-9,
+                wavelength(i + SPECTRUM_WAVELENGTH_RANGE.start()),
                 center_m,
                 width_m,
             )

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -11,8 +11,14 @@ use std::{ops::Index, sync::LazyLock};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    colorant::Colorant, data::observers::CIE1931, error::CmtError, illuminant::Illuminant,
-    rgbspace::RgbSpace, spectrum::Spectrum, traits::Light, xyz::XYZ,
+    colorant::Colorant,
+    data::observers::CIE1931,
+    error::CmtError,
+    illuminant::Illuminant,
+    rgbspace::RgbSpace,
+    spectrum::{Spectrum, SPECTRUM_WAVELENGTH_RANGE},
+    traits::Light,
+    xyz::XYZ,
 };
 
 /// Nummer of Test Color Sample Spectra
@@ -26,7 +32,18 @@ const N_TCS: usize = 14;
 pub static TCS: LazyLock<[Colorant; N_TCS]> = LazyLock::new(|| {
     let s_vec: Vec<Colorant> = TCS5
         .column_iter()
-        .map(|s| Colorant(Spectrum::linear_interpolate(&[380.0, 780.0], s.as_slice()).unwrap()))
+        .map(|s| {
+            Colorant(
+                Spectrum::linear_interpolate(
+                    &[
+                        *SPECTRUM_WAVELENGTH_RANGE.start() as f64,
+                        *SPECTRUM_WAVELENGTH_RANGE.end() as f64,
+                    ],
+                    s.as_slice(),
+                )
+                .unwrap(),
+            )
+        })
         .collect();
     s_vec.try_into().unwrap()
 });

--- a/src/munsell_matt.rs
+++ b/src/munsell_matt.rs
@@ -18,7 +18,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     data::munsell_matt::{MUNSELL_MATT_DATA, MUNSELL_MATT_KEYS},
     error::CmtError,
-    spectrum::Spectrum,
+    spectrum::{Spectrum, SPECTRUM_WAVELENGTH_RANGE},
     traits::Filter,
 };
 
@@ -41,7 +41,14 @@ impl MunsellMatt {
             .collect::<Vec<f64>>()
             .try_into()
             .unwrap();
-        let spectrum = Spectrum::linear_interpolate(&[380.0, 780.0], &data).unwrap();
+        let spectrum = Spectrum::linear_interpolate(
+            &[
+                *SPECTRUM_WAVELENGTH_RANGE.start() as f64,
+                *SPECTRUM_WAVELENGTH_RANGE.end() as f64,
+            ],
+            &data,
+        )
+        .unwrap();
         MunsellMatt(key.to_string(), spectrum)
     }
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,3 +1,4 @@
+use crate::spectrum::SPECTRUM_WAVELENGTH_RANGE;
 use num_traits::ToPrimitive;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -161,5 +162,6 @@ pub fn to_wavelength<T: ToPrimitive>(x: T, xmin: T, xmax: T) -> f64 {
     let xmax = xmax.to_f64().unwrap_or(f64::NAN);
     let x = x.to_f64().unwrap_or(f64::NAN);
     let f = (x - xmin) / (xmax - xmin);
-    380E-9 * (1.0 - f) + 780E-9 * f
+    *SPECTRUM_WAVELENGTH_RANGE.start() as f64 * 1E-9 * (1.0 - f)
+        + *SPECTRUM_WAVELENGTH_RANGE.end() as f64 * 1E-9 * f
 }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -162,6 +162,6 @@ pub fn to_wavelength<T: ToPrimitive>(x: T, xmin: T, xmax: T) -> f64 {
     let xmax = xmax.to_f64().unwrap_or(f64::NAN);
     let x = x.to_f64().unwrap_or(f64::NAN);
     let f = (x - xmin) / (xmax - xmin);
-    *SPECTRUM_WAVELENGTH_RANGE.start() as f64 * 1E-9 * (1.0 - f)
-        + *SPECTRUM_WAVELENGTH_RANGE.end() as f64 * 1E-9 * f
+    wavelength(*SPECTRUM_WAVELENGTH_RANGE.start()) * (1.0 - f)
+        + wavelength(*SPECTRUM_WAVELENGTH_RANGE.end()) * f
 }

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -470,7 +470,7 @@ impl Index<usize> for Spectrum {
 impl IndexMut<usize> for Spectrum {
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
         match i {
-            380..=780 => &mut self.0[(i - 380, 0)],
+            380..=780 => &mut self.0[(i - SPECTRUM_WAVELENGTH_RANGE.start(), 0)],
             ..380 => &mut self.0[(0, 0)],
             781.. => &mut self.0[(400, 0)],
         }
@@ -487,7 +487,7 @@ pub fn wavelengths<T: ToPrimitive, const N: usize>(v: [T; N]) -> [f64; N] {
     v.map(|x| wavelength(x))
 }
 
-/// Linear interpolatino over a dataset over an equidistant wavelength domain
+/// Linear interpolation over a dataset over an equidistant wavelength domain
 fn linterp(mut wl: [f64; 2], data: &[f64]) -> Result<[f64; NS], CmtError> {
     wl.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let [wl, wh] = wavelengths(wl);
@@ -495,7 +495,7 @@ fn linterp(mut wl: [f64; 2], data: &[f64]) -> Result<[f64; NS], CmtError> {
 
     let mut spd = [0f64; NS];
     spd.iter_mut().enumerate().for_each(|(i, v)| {
-        let l = (i + 380) as f64 * 1E-9; // wavelength in meters
+        let l = (i + SPECTRUM_WAVELENGTH_RANGE.start()) as f64 * 1E-9; // wavelength in meters
         let t = ((l - wl) / (wh - wl)).clamp(0.0, 1.0); // length parameter
         let tf = t * dlm1 as f64;
         let j = tf.trunc() as usize;
@@ -540,7 +540,7 @@ fn linterp_irr(wl: &[f64], data: &[f64]) -> Result<[f64; NS], CmtError> {
         };
         let mut spd = [0f64; NS];
         spd.iter_mut().enumerate().for_each(|(i, v)| {
-            let k = (i + 380) * 1000;
+            let k = (i + SPECTRUM_WAVELENGTH_RANGE.start()) * 1000;
             let p = a.range(..k).next_back(); // find values < k
             let n = a.range(k..).next(); // find values >= k
             match (p, n) {
@@ -585,7 +585,7 @@ fn sprinterp(mut wl: [f64; 2], data: &[f64]) -> Result<[f64; NS], CmtError> {
 
     let mut spd = [0f64; NS];
     spd.iter_mut().enumerate().for_each(|(i, v)| {
-        let l = (i + 380) as f64 * 1E-9; // wavelength in meters
+        let l = (i + SPECTRUM_WAVELENGTH_RANGE.start()) as f64 * 1E-9; // wavelength in meters
         let t = (l - wl) / (wh - wl); // length parameter
         let th = (t * f64_imax).clamp(0.0, f64_imax);
         let h = th.fract();


### PR DESCRIPTION
This PR replaces many hardcoded integer literals with the values `380` or `780` with the corresponding `SPECTRUM_WAVELENGTH_RANGE.start()` and `SPECTRUM_WAVELENGTH_RANGE.end()`. This makes the code a bit longer in some places for sure. But repeating hard coded literals is often a code smell. This way the intent might become clearer. This also allows changing what wavelength range the library supports easier (hypothetical change by us or someone forking the library).