### PR TITLE
Make indexing into a Spectrum with invalid indices panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Make indexing into a `Spectrum` with out of bounds wavelengths cause a panic, instead
+  of returning `NaN`s or modifying the first or last values.
+
+
 ## [0.0.5] - 2025-05-14
 
 ### Added

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -450,30 +450,26 @@ impl MulAssign<f64> for Spectrum {
 /// Read a spectrum value by an integer wavelength value in the range from 380..=780
 /// nanometer.
 ///
-/// Invalid indices will result in a f64::NAN value.
+/// # Panics
+///
+/// Panic if the index is less than 380 or greater than 780.
 impl Index<usize> for Spectrum {
     type Output = f64;
 
     fn index(&self, i: usize) -> &Self::Output {
-        if !SPECTRUM_WAVELENGTH_RANGE.contains(&i) {
-            &f64::NAN
-        } else {
-            &self.0[(i - SPECTRUM_WAVELENGTH_RANGE.start(), 0)]
-        }
+        &self.0[(i - SPECTRUM_WAVELENGTH_RANGE.start(), 0)]
     }
 }
 
 /// Mutable Access a spectrum value by an integer wavelength value in the range from 380..=780
 /// nanometer.
 ///
-/// Out of range indices will set the edge values.
+/// # Panics
+///
+/// Panic if the index is less than 380 or greater than 780.
 impl IndexMut<usize> for Spectrum {
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
-        match i {
-            380..=780 => &mut self.0[(i - 380, 0)],
-            ..380 => &mut self.0[(0, 0)],
-            781.. => &mut self.0[(400, 0)],
-        }
+        &mut self.0[(i - SPECTRUM_WAVELENGTH_RANGE.start(), 0)]
     }
 }
 
@@ -663,13 +659,31 @@ mod tests {
     fn index_test() {
         let mut s = *Colorant::white().spectrum();
 
+        assert_ulps_eq!(s[500], 1.0);
+
         // Set a spectral value
         s[500] = 0.5;
         assert_ulps_eq!(s[500], 0.5);
 
-        // A read from an index out of the 380..=780 range with given f64::NAN.
-        s[300] = 0.5;
-        assert!(s[300].is_nan());
+        // Check that neigbhboring values are not changed
+        assert_ulps_eq!(s[499], 1.0);
+        assert_ulps_eq!(s[501], 1.0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn index_out_of_bounds() {
+        let s = *Colorant::white().spectrum();
+
+        let _ = s[300];
+    }
+
+    #[test]
+    #[should_panic]
+    fn index_mut_out_of_bounds() {
+        let mut s = *Colorant::white().spectrum();
+
+        s[800] = 0.5;
     }
 
     #[test]


### PR DESCRIPTION
I don't know how you use `colorimetry` exactly. So maybe the existing behavior is really desirable for you. But I find the way that the indexing into a `Spectrum` currently works to be uncommon, and can easier lead to harder-to-debug bugs when using the library.

I most of the time prefer failing loudly rather than failing silently. Failing silently here meaning that when the user does something wrong, you try to smooth it over and do some "best effort guess" instead of throwing an error. This might lead a user who has some indexing bug to scratch their head for hours about why the data they get out looks so strange. If we instead throw an error they will directly see that something is wrong with their code computing the wavelength they index by.

Is there any real use case where a user might have out of bounds wavelengths and that yielding `NaN`s or editing the edge values would be the correct thing to do? Even if there is, and we deem it uncommon, the user can still create that behavior manually by writing a little extra code around their indexing operations anyway.