### PR TITLE
Fix `WideRgb::compress` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   of returning `NaN`s or modifying the first or last values.
 
 
+### Fixed
+- Fix bug in `WideRgb::compress`. Previously `WideRgb` instances with only positive channel values
+  would have its lowest channel value invalidly scaled down to 0.0. And instances with only values
+  below 1.0 would have its highest channel value invalidly scaled up to 1.0.
+
+
 ## [0.0.5] - 2025-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * **Security**: in case of vulnerabilities.
 
 ## Unreleased
+
 ### Added
 - - Add `r()`, `g()` and `b()` methods to `WideRgb` for easy access to each channel value.
-
 
 ### Removed
 - Remove undocumented `XYZ::srgb` method that both clamped out-of-gamut values and converted
@@ -24,11 +24,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   more explicit by converting to the `Rgb` type in between with one of the provided conversion
   methods.
 
-
 ### Changed
 - Make indexing into a `Spectrum` with out of bounds wavelengths cause a panic, instead
   of returning `NaN`s or modifying the first or last values.
-
 
 ### Fixed
 - Fix bug in `WideRgb::compress`. Previously `WideRgb` instances with only positive channel values

--- a/src/widergb.rs
+++ b/src/widergb.rs
@@ -206,13 +206,14 @@ impl WideRgb {
     pub fn compress(&self) -> Rgb {
         // Amount to add to get all channels positive
         let translate = -self.rgb.min().min(0.0);
-
-        let non_negative_rgb = self.rgb.add_scalar(translate);
-
         // The scaling needed to get all channels below 1.0
-        let scale = non_negative_rgb.max().max(1.0);
+        let scale = (self.rgb.max() + translate).max(1.0);
 
-        let in_gamut_rgb = non_negative_rgb / scale;
+        let in_gamut_rgb = if translate != 0.0 || scale != 1.0 {
+            self.rgb.add_scalar(translate) / scale
+        } else {
+            self.rgb
+        };
         Rgb {
             rgb: in_gamut_rgb,
             observer: self.observer,

--- a/src/widergb.rs
+++ b/src/widergb.rs
@@ -214,7 +214,9 @@ impl WideRgb {
             let gray_value = rgb_min.clamp(0.0, 1.0);
             nalgebra::Vector3::repeat(gray_value)
         } else if rgb_min < 0.0 || rgb_max > 1.0 {
-            self.rgb.map(|v| (v - rgb_min) / (rgb_max - rgb_min))
+            let translate = rgb_min.min(0.0);
+            let scale = (rgb_max - translate).max(1.0);
+            self.rgb.map(|v| (v - translate) / scale)
         } else {
             self.rgb
         };


### PR DESCRIPTION
I found a bug in the new `WideRgb::compress` method. Previously `WideRgb` instances with only positive channel values would have its lowest channel value invalidly scaled down to 0.0. And instances with only values below 1.0 would have its highest channel value invalidly scaled up to 1.0.

I confirmed this by adding quite a lot of tests. The amount of tests are actually justified in my opinion. Because I added them one at a time when trying to fix the bug, but there was always some more edge case that my fix failed to correct for. So I tried to be as exhaustive as possible.

I then applied the simplest fix I could find that made all tests pass. However, I thought the resulting code was very complex compared to the naive implementation I described in https://github.com/harbik/colorimetry/issues/32#issuecomment-2868735203. So I tried my implementation as well, and it also passed all tests.

I was then curious to see if the previous implementation was faster (at the cost of being complex). So I added benchmarks. Maybe it's time that we take the step to introduce benchmarks in general, if we want to optimize some other parts of this library later? `criterion` is the only benchmarking lib I have used in Rust, so I reached for that. Adding a few benchmarks is quite straight forward, as you can see in the code. You can check out their getting started guide [here](https://bheisler.github.io/criterion.rs/book/getting_started.html) if you are interested.

The benchmarking results showed that my naive implementation was on par with the previous implementation for the compression of out-of-gamut RGB values, but slower for in-gamut values. Not very surprising since the previous implementation had a simpler code path without matrix operations when all channel values were in the acceptable range. I added this optimization into my new algorithm as well and then the results then were that this new implementation is identical in speed compared to the previous implementation. I personally think this final proposal is easier to understand than the code that was there before. And it is proven to be of comparative performance.