### PR TITLE
Remove reference white from `XYZ` struct

### DIFF
--- a/src/cam.rs
+++ b/src/cam.rs
@@ -37,9 +37,17 @@ pub struct CieCam16 {
 
 impl CieCam16 {
     /// CIECAM16 coordinates for a particular set of viewing conditions.
-    fn new(xyz: XYZ, vc: ViewConditions) -> Result<Self, CmtError> {
-        let xyz0 = xyz.xyz.ok_or(CmtError::NoColorant)?;
-        let xyzn0 = xyz.xyzn;
+    ///
+    /// # Errors
+    ///
+    /// Returns `CmtError::RequireSameObserver` if the observer of the given XYZ and reference
+    /// white values are not the same.
+    fn new(xyz: XYZ, xyzn: XYZ, vc: ViewConditions) -> Result<Self, CmtError> {
+        if xyz.observer != xyzn.observer {
+            return Err(CmtError::RequireSameObserver);
+        }
+        let xyz0 = xyz.xyz;
+        let xyzn0 = xyzn.xyz;
         let ReferenceValues {
             n,
             z,

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -134,7 +134,11 @@ impl Colorant {
             .data()
             .xyz(illuminant, Some(self))
             .set_illuminance(100.0);
-        CieLab::try_from(xyz).unwrap()
+        let xyzn = obs
+            .data()
+            .xyz_from_spectrum(&illuminant.spectrum())
+            .set_illuminance(100.0);
+        CieLab::from_xyz(xyz, xyzn).unwrap()
     }
 }
 

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use approx::{assert_abs_diff_eq, AbsDiffEq};
-use nalgebra::SVector;
+use nalgebra::{coordinates::XYZW, SVector};
 
 use crate::{
     error::CmtError,
@@ -14,6 +14,7 @@ use crate::{
     spectrum::{wavelengths, Spectrum, NS},
     std_illuminants,
     traits::{Filter, Light},
+    xyz::XYZWithRefWhite,
 };
 
 /// # Colorant
@@ -134,11 +135,11 @@ impl Colorant {
             .data()
             .xyz(illuminant, Some(self))
             .set_illuminance(100.0);
-        let xyzn = obs
+        let white = obs
             .data()
             .xyz_from_spectrum(&illuminant.spectrum())
             .set_illuminance(100.0);
-        CieLab::from_xyz(xyz, xyzn).unwrap()
+        CieLab::from_xyz(XYZWithRefWhite::new(xyz, white.xyz))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,6 @@ pub enum CmtError {
     RequiresDistinctPoints,
     #[error("Arguments require the identical Standard Observer")]
     RequireSameObserver,
-    #[error("No Reference White values allowed")]
-    NoReferenceWhiteAllowed,
     #[error("Lines do not intersect")]
     NoIntersection,
     #[error("Wavelength out of range")]

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -212,7 +212,7 @@ impl Illuminant {
     /// none is provided.
     pub fn xyz(&self, obs_opt: Option<Observer>) -> XYZ {
         let obs = obs_opt.unwrap_or_default();
-        obs.data().xyz_from_spectrum(&self.0, None)
+        obs.data().xyz_from_spectrum(&self.0)
     }
 
     /// Calculate the correlated color temperature (CCT) of the illuminant.
@@ -336,7 +336,7 @@ impl Illuminant {
 fn test_d_illuminant() {
     use crate::prelude::*;
     let s = Illuminant::d_illuminant(6504.0).unwrap();
-    let xyz = CIE1931.xyz_from_spectrum(&s, None).set_illuminance(100.0);
+    let xyz = CIE1931.xyz_from_spectrum(&s).set_illuminance(100.0);
     approx::assert_ulps_eq!(xyz, CIE1931.xyz_d65(), epsilon = 2E-2);
 }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -1,6 +1,7 @@
 use approx::ulps_eq;
 use nalgebra::{RowVector3, Vector3};
 
+use crate::xyz::XYZWithRefWhite;
 use crate::{error::CmtError, prelude::Observer, xyz::XYZ};
 use strum_macros::Display;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -14,22 +15,14 @@ pub struct CieLab {
 }
 
 impl CieLab {
-    /// Creates a new CieLab instance from the given XYZ and reference white values.
-    ///
-    /// # Errors
-    ///
-    /// Returns `CmtError::RequireSameObserver` if the observer of the given XYZ and reference
-    /// white values are not the same.
-    pub fn from_xyz(xyz: XYZ, white: XYZ) -> Result<Self, CmtError> {
-        if xyz.observer != white.observer {
-            return Err(CmtError::RequireSameObserver);
-        }
-        let xyzn = white.xyz;
-        Ok(Self {
-            lab: lab(xyz.xyz, xyzn),
+    /// Creates a new CieLab instance from the given XYZ tristimulus value with reference white.
+    pub fn from_xyz(xyz: XYZWithRefWhite) -> Self {
+        let xyzn = xyz.white();
+        Self {
+            lab: lab(xyz.xyz().xyz, xyzn),
             xyzn,
-            observer: xyz.observer,
-        })
+            observer: xyz.observer(),
+        }
     }
 
     pub fn delta_e(&self, other: &Self) -> Result<f64, CmtError> {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -13,29 +13,24 @@ pub struct CieLab {
     pub(crate) xyzn: Vector3<f64>, // Reference white tristimulus value
 }
 
-impl TryFrom<XYZ> for CieLab {
-    type Error = CmtError;
-
-    fn try_from(xyz_val: XYZ) -> Result<Self, Self::Error> {
-        if let Some(xyz) = xyz_val.xyz {
-            let lab = lab(xyz, xyz_val.xyzn);
-            Ok(Self {
-                observer: xyz_val.observer,
-                lab,
-                xyzn: xyz_val.xyzn,
-            })
-        } else {
-            Err(CmtError::NoColorant)
-        }
-    }
-}
-
 impl CieLab {
-    /*
-    pub fn new(xyzn: Vector3<f64>, xyz: Vector3<f64>) -> CieLab {
-        CieLab {lab: lab(xyz, xyzn), xyzn}
+    /// Creates a new CieLab instance from the given XYZ and reference white values.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CmtError::RequireSameObserver` if the observer of the given XYZ and reference
+    /// white values are not the same.
+    pub fn from_xyz(xyz: XYZ, white: XYZ) -> Result<Self, CmtError> {
+        if xyz.observer != white.observer {
+            return Err(CmtError::RequireSameObserver);
+        }
+        let xyzn = white.xyz;
+        Ok(Self {
+            lab: lab(xyz.xyz, xyzn),
+            xyzn,
+            observer: xyz.observer,
+        })
     }
-     */
 
     pub fn delta_e(&self, other: &Self) -> Result<f64, CmtError> {
         if ulps_eq!(self.xyzn, other.xyzn) {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -58,7 +58,7 @@ use crate::{
     spectrum::{Spectrum, NS, SPECTRUM_WAVELENGTH_RANGE},
     std_illuminants::StdIlluminant,
     traits::{Filter, Light},
-    xyz::XYZ,
+    xyz::{XYZWithRefWhite, XYZ},
 };
 use nalgebra::{Matrix3, SMatrix, Vector3};
 use std::{
@@ -315,14 +315,14 @@ impl ObserverData {
     pub fn lab_d65(&self, filter: &dyn Filter) -> CieLab {
         let xyz = self.xyz(&StdIlluminant::D65, Some(filter));
         let xyzn = self.xyz_from_spectrum(&StdIlluminant::D65.spectrum());
-        CieLab::from_xyz(xyz, xyzn).unwrap()
+        CieLab::from_xyz(XYZWithRefWhite::new(xyz, xyzn.xyz))
     }
 
     /// Calculates the L*a*b* CIELAB D50 values of a Colorant, using D65 as an illuminant.
     pub fn lab_d50(&self, filter: &dyn Filter) -> CieLab {
         let xyz = self.xyz(&StdIlluminant::D50, Some(filter));
         let xyzn = self.xyz_from_spectrum(&StdIlluminant::D50.spectrum());
-        CieLab::from_xyz(xyz, xyzn).unwrap()
+        CieLab::from_xyz(XYZWithRefWhite::new(xyz, xyzn.xyz))
     }
 
     /// Returns the wavelength range (in nanometer) for the _horse shoe_,

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -213,17 +213,10 @@ impl Rgb {
     /// Converts the RGB value to a tri-stimulus XYZ value
     pub fn xyz(&self) -> XYZ {
         const YW: f64 = 100.0;
-        let xyzn = self
-            .observer
-            .data()
-            .xyz(&self.space.data().white, None)
-            .set_illuminance(100.0)
-            .xyzn;
         let xyz = self.observer.data().rgb2xyz(&self.space) * self.rgb;
         XYZ {
             observer: self.observer,
-            xyz: Some(xyz.map(|v| v * YW)),
-            xyzn,
+            xyz: xyz.map(|v| v * YW),
         }
     }
 }
@@ -291,7 +284,7 @@ impl Filter for Rgb {
     ///
     /// // Compare with the CIE D65 reference white point
     /// let d65: XYZ = CIE1931.xyz(&StdIlluminant::D65, Some(&rgb));
-    /// approx::assert_ulps_eq!(d65, XYZ_D65WHITE, epsilon = 1e-2);
+    /// approx::assert_ulps_eq!(d65, XYZ_D65, epsilon = 1e-2);
     /// ```
     ///
     /// # Implementation Details

--- a/src/rgbspace.rs
+++ b/src/rgbspace.rs
@@ -267,7 +267,7 @@ mod rgbspace_tests {
             let iter = primaries_chromaticity.into_iter().zip(primaries_colorants);
             for (chromaticity, colorant) in iter {
                 let computed_chromaticity = CIE1931
-                    .xyz_from_spectrum(&colorant.spectrum(), None)
+                    .xyz_from_spectrum(&colorant.spectrum())
                     .chromaticity();
                 assert_ulps_eq!(
                     chromaticity.to_array().as_ref(),

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -619,14 +619,14 @@ mod tests {
     fn test_spectrum_from_rgb() {
         let white: Stimulus = Rgb::new(1.0, 1.0, 1.0, None, None).unwrap().into();
         approx::assert_ulps_eq!(
-            CIE1931.xyz_from_spectrum(&white, None),
+            CIE1931.xyz_from_spectrum(&white),
             CIE1931.xyz_d65().set_illuminance(100.0),
             epsilon = 1E-6
         );
         let red = Stimulus::from_srgb(255, 0, 0);
         assert_ulps_eq!(
             CIE1931
-                .xyz_from_spectrum(&red, None)
+                .xyz_from_spectrum(&red)
                 .chromaticity()
                 .to_array()
                 .as_ref(),
@@ -644,12 +644,12 @@ mod tests {
 
     #[test]
     fn test_chromaticity() {
-        let xyz0 = CIE1931.xyz_from_spectrum(&D65, None);
+        let xyz0 = CIE1931.xyz_from_spectrum(&D65);
         let [x0, y0] = xyz0.chromaticity().to_array();
 
         let illuminance = D65.illuminance(&CIE1931);
         let d65 = D65.clone().set_illuminance(&CIE1931, 100.0);
-        let xyz = CIE1931.xyz_from_spectrum(&d65, None);
+        let xyz = CIE1931.xyz_from_spectrum(&d65);
         let [x, y] = xyz.chromaticity().to_array();
 
         assert_ulps_eq!(x0, x);
@@ -704,10 +704,7 @@ mod tests {
     #[test]
     fn ee() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(
-                &Illuminant::equal_energy().set_illuminance(&CIE1931, 100.0),
-                None,
-            )
+            .xyz_from_spectrum(&Illuminant::equal_energy().set_illuminance(&CIE1931, 100.0))
             .chromaticity();
         assert_ulps_eq!(chromaticity.x(), 0.333_3, epsilon = 5E-5);
         assert_ulps_eq!(chromaticity.y(), 0.333_3, epsilon = 5E-5);
@@ -716,7 +713,7 @@ mod tests {
     #[test]
     fn d65() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(&Illuminant::d65().set_illuminance(&CIE1931, 100.0), None)
+            .xyz_from_spectrum(&Illuminant::d65().set_illuminance(&CIE1931, 100.0))
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.312_72, epsilon = 5E-5);
@@ -734,7 +731,7 @@ mod tests {
     #[test]
     fn d50() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(&Illuminant::d50().set_illuminance(&CIE1931, 100.0), None)
+            .xyz_from_spectrum(&Illuminant::d50().set_illuminance(&CIE1931, 100.0))
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.345_67, epsilon = 5E-5);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,7 +19,7 @@ pub trait Light {
     /// The illuminance value is optional, and if not provided, the actual luminous values in the
     /// spectrum are used.
     fn xyzn(&self, observer: Observer, y: Option<f64>) -> XYZ {
-        let xyz = observer.data().xyz_from_spectrum(&self.spectrum(), None);
+        let xyz = observer.data().xyz_from_spectrum(&self.spectrum());
         if let Some(illuminance) = y {
             xyz.set_illuminance(illuminance)
         } else {

--- a/src/widergb.rs
+++ b/src/widergb.rs
@@ -130,17 +130,10 @@ impl WideRgb {
     /// Converts the RGB value to a tri-stimulus XYZ value
     pub fn xyz(&self) -> XYZ {
         const YW: f64 = 100.0;
-        let xyzn = self
-            .observer
-            .data()
-            .xyz(&self.space.data().white, None)
-            .set_illuminance(100.0)
-            .xyzn;
         let xyz = self.observer.data().rgb2xyz(&self.space) * self.rgb;
         XYZ {
             observer: self.observer,
-            xyz: Some(xyz.map(|v| v * YW)),
-            xyzn,
+            xyz: xyz.map(|v| v * YW),
         }
     }
 

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -580,6 +580,31 @@ impl XYZ {
     }
 }
 
+/// A CIE XYZ Tristimulus value with a reference white point.
+pub struct XYZWithRefWhite {
+    xyz: XYZ,
+    white: Vector3<f64>,
+}
+
+impl XYZWithRefWhite {
+    /// Creates a new `XYZWithRefWhite` object with the given XYZ and reference white values.
+    pub fn new(xyz: XYZ, white: Vector3<f64>) -> Self {
+        Self { xyz, white }
+    }
+
+    pub fn observer(&self) -> Observer {
+        self.xyz.observer
+    }
+
+    pub fn xyz(&self) -> XYZ {
+        self.xyz
+    }
+
+    pub fn white(&self) -> Vector3<f64> {
+        self.white
+    }
+}
+
 #[cfg(test)]
 mod xyz_test {
     use crate::prelude::*;


### PR DESCRIPTION
This PR tries to implement what we have been discussing in #16 and #32 as well as other threads. This has come up multiple times. That because the `XYZ` value could both represent an illuminant and a colorant (with a reference white) it had multiple purposes, and that made some code harder to understand, and some methods have more error cases than really needed.

I'm marking this as a draft PR since I did not fully finish the migration. I threw together a first attempt to show that I'm working on this. And to get a place where we can discuss this change in more detail. Such as where is a reference white needed? Should we have a dedicated struct for that?

There are a few places here where both a tristimulus value and a reference white is needed. And I (for now) take them as two `XYZ` values in separate arguments. But this introduce the error case of them having different observers, so this is not ideal. A separate `XYZWithRefWhite` would solve this. So maybe I should add one of those?

Can you spot any other errors I have made? Overall I have to say the code became much simpler with this change.