### PR TITLE
Removed reference white from XYZ, passes all tests.

### DIFF
--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -130,11 +130,10 @@ impl Colorant {
     pub fn cielab(&self, illuminant_opt: Option<&dyn Light>, obs_opt: Option<Observer>) -> CieLab {
         let illuminant = illuminant_opt.unwrap_or(&D65);
         let obs = obs_opt.unwrap_or_default();
-        let xyz = obs
-            .data()
-            .xyz(illuminant, Some(self))
-            .set_illuminance(100.0);
-        CieLab::try_from(xyz).unwrap()
+        let xyzn = obs.data().xyz(illuminant, None).set_illuminance(100.0);
+        let xyz = obs.data().xyz(illuminant, Some(self));
+        // unwrap is safe here, as we know the illuminant and observer are valid
+        CieLab::new(xyz, xyzn).unwrap()
     }
 }
 

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -112,7 +112,7 @@ impl TryFrom<&Illuminant> for CRI {
     fn try_from(illuminant: &Illuminant) -> Result<Self, Self::Error> {
         let illuminant = &illuminant.clone().set_illuminance(&CIE1931, 100.0);
         // Calculate Device Under Test (dut) XYZ illuminant and sample values
-        let xyz_dut = CIE1931.xyz_from_spectrum(illuminant, None);
+        let xyz_dut = CIE1931.xyz_from_spectrum(illuminant);
         let xyz_dut_samples: [XYZ; N_TCS] = TCS
             .each_ref()
             .map(|colorant| CIE1931.xyz(illuminant, Some(colorant)));
@@ -127,7 +127,7 @@ impl TryFrom<&Illuminant> for CRI {
         };
 
         // Calculate the reference illuminant values
-        let xyz_ref = CIE1931.xyz_from_spectrum(&illuminant_ref, None);
+        let xyz_ref = CIE1931.xyz_from_spectrum(&illuminant_ref);
         let xyz_ref_samples: [XYZ; N_TCS] = TCS
             .each_ref()
             .map(|colorant| CIE1931.xyz(&illuminant_ref, Some(colorant)));
@@ -141,8 +141,7 @@ impl TryFrom<&Illuminant> for CRI {
             .map(|(xyzr, xyz)| {
                 let cdti = cd(xyz.uv60());
                 let uv_vk = uv_kries(cdt, cdr, cdti);
-                let xyz_vk =
-                    XYZ::from_luv60(uv_vk[0], uv_vk[1], Some(xyz.xyz.unwrap().y), None).unwrap();
+                let xyz_vk = XYZ::from_luv60(uv_vk[0], uv_vk[1], Some(xyz.xyz.y), None).unwrap();
                 let uvw = xyz_vk.uvw64(xyz_ref);
                 let uvwr = xyzr.uvw64(xyz_ref);
                 100.0

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -212,7 +212,7 @@ impl Illuminant {
     /// none is provided.
     pub fn xyz(&self, obs_opt: Option<Observer>) -> XYZ {
         let obs = obs_opt.unwrap_or_default();
-        obs.data().xyz_from_spectrum(&self.0, None)
+        obs.data().xyz_from_spectrum(&self.0)
     }
 
     /// Calculate the correlated color temperature (CCT) of the illuminant.
@@ -336,7 +336,7 @@ impl Illuminant {
 fn test_d_illuminant() {
     use crate::prelude::*;
     let s = Illuminant::d_illuminant(6504.0).unwrap();
-    let xyz = CIE1931.xyz_from_spectrum(&s, None).set_illuminance(100.0);
+    let xyz = CIE1931.xyz_from_spectrum(&s).set_illuminance(100.0);
     approx::assert_ulps_eq!(xyz, CIE1931.xyz_d65(), epsilon = 2E-2);
 }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -13,29 +13,18 @@ pub struct CieLab {
     pub(crate) xyzn: Vector3<f64>, // Reference white tristimulus value
 }
 
-impl TryFrom<XYZ> for CieLab {
-    type Error = CmtError;
-
-    fn try_from(xyz_val: XYZ) -> Result<Self, Self::Error> {
-        if let Some(xyz) = xyz_val.xyz {
-            let lab = lab(xyz, xyz_val.xyzn);
-            Ok(Self {
-                observer: xyz_val.observer,
-                lab,
-                xyzn: xyz_val.xyzn,
-            })
+impl CieLab {
+    pub fn new(xyz: XYZ, xyzn: XYZ) -> Result<CieLab, CmtError> {
+        if xyz.observer != xyzn.observer {
+            Err(CmtError::RequireSameObserver)
         } else {
-            Err(CmtError::NoColorant)
+            Ok(CieLab {
+                observer: xyz.observer,
+                lab: lab(xyz.xyz, xyzn.xyz),
+                xyzn: xyzn.xyz,
+            })
         }
     }
-}
-
-impl CieLab {
-    /*
-    pub fn new(xyzn: Vector3<f64>, xyz: Vector3<f64>) -> CieLab {
-        CieLab {lab: lab(xyz, xyzn), xyzn}
-    }
-     */
 
     pub fn delta_e(&self, other: &Self) -> Result<f64, CmtError> {
         if ulps_eq!(self.xyzn, other.xyzn) {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -167,15 +167,15 @@ impl ObserverData {
     /// As a light, it is the light emitted from the pixel, as a filter it is the RGB-composite
     /// filter which is applied to the underlying standard illuminant of color space.
     pub fn xyz(&self, light: &dyn Light, filter: Option<&dyn Filter>) -> XYZ {
-        // let xyzn = self.xyz_cie_table(illuminant, None);
         let xyzn = light.xyzn(self.tag, None);
-        let xyz = if let Some(flt) = filter {
+        if let Some(flt) = filter {
             let s = *light.spectrum() * *flt.spectrum();
-            self.xyz_from_spectrum(&s, Some(xyzn))
+            let xyz = self.xyz_from_spectrum(&s);
+            let scale = 100.0 / xyzn.xyz.y;
+            xyz * scale
         } else {
             xyzn
-        };
-        xyz.set_illuminance(100.0)
+        }
     }
 
     /**
@@ -186,15 +186,9 @@ impl ObserverData {
         This method produces the raw XYZ data, not normalized to 100.0
 
     */
-    pub fn xyz_from_spectrum(&self, spectrum: &Spectrum, rhs: Option<XYZ>) -> XYZ {
+    pub fn xyz_from_spectrum(&self, spectrum: &Spectrum) -> XYZ {
         let xyz = self.data * spectrum.0 * self.lumconst;
-        if let Some(xyz0) = rhs {
-            // A illuminant/colorant
-            XYZ::from_vecs(xyz0.xyzn, Some(xyz), self.tag)
-        } else {
-            // illuminant only
-            XYZ::from_vecs(xyz, None, self.tag)
-        }
+        XYZ::from_vecs(xyz, self.tag)
     }
 
     /// Returns the observer's color matching function (CMF) data as an [XYZ] tristimulus
@@ -212,16 +206,16 @@ impl ObserverData {
             .data
             .column(wavelength - SPECTRUM_WAVELENGTH_RANGE.start())
             .as_ref();
-        Ok(XYZ::from_vecs(Vector3::new(x, y, z), None, self.tag))
+        Ok(XYZ::from_vecs(Vector3::new(x, y, z), self.tag))
     }
 
-    /**
-        Tristimulus values for the Standard Illuminants in this library.
-
-        Values are not normalized by default, unless an illuminance value is provided.
-    */
+    /// Tristimulus values for the Standard Illuminants in this library.
+    ///
+    /// Values are not normalized by default, unless an illuminance value is provided.
+    ///
+    /// TODO: buffer values
     pub fn xyz_cie_table(&self, std_illuminant: &StdIlluminant, illuminance: Option<f64>) -> XYZ {
-        let xyz = self.xyz_from_spectrum(std_illuminant.illuminant(), None);
+        let xyz = self.xyz_from_spectrum(std_illuminant.illuminant());
         if let Some(l) = illuminance {
             xyz.set_illuminance(l)
         } else {
@@ -272,21 +266,21 @@ impl ObserverData {
         illuminant: &StdIlluminant,
         f: impl Fn(f64) -> f64,
     ) -> XYZ {
-        let s = illuminant.illuminant();
-        let xyzn = self.xyz_cie_table(illuminant, None).xyzn;
-        let xyz =
-            self.data.column_iter().zip(s.0 .0.iter()).enumerate().fold(
-                Vector3::zeros(),
-                |acc, (i, (cmfi, sv))| {
-                    acc + cmfi * f(i as f64 / (NS - 1) as f64).clamp(0.0, 1.0) * *sv
-                },
-            );
+        let ill = illuminant.illuminant();
+        let xyzn = self.xyz_cie_table(illuminant, None);
+        let xyz = self
+            .data
+            .column_iter()
+            .zip(ill.0 .0.iter())
+            .enumerate()
+            .fold(Vector3::zeros(), |acc, (i, (cmfi, sv))| {
+                acc + cmfi * f(i as f64 / (NS - 1) as f64).clamp(0.0, 1.0) * *sv
+            });
+        let scale = 100.0 / xyzn.xyz.y;
         XYZ {
-            xyz: Some(xyz * self.lumconst),
-            xyzn,
+            xyz: xyz * self.lumconst * scale,
             observer: self.tag,
         }
-        .set_illuminance(100.0)
     }
 
     /**
@@ -299,7 +293,7 @@ impl ObserverData {
         and yw is set to None.
     */
     pub fn xyz_fn_illuminant(&self, f: impl Fn(f64) -> f64) -> XYZ {
-        let xyzn = self
+        let xyz = self
             .data
             .column_iter()
             .enumerate()
@@ -307,8 +301,7 @@ impl ObserverData {
                 acc + cmf * f(i as f64 / (NS - 1) as f64)
             });
         XYZ {
-            xyz: None,
-            xyzn,
+            xyz,
             observer: self.tag,
         }
     }
@@ -332,16 +325,18 @@ impl ObserverData {
     /// Accepts a Colorant Spectrum only.
     /// Returns f64::NAN's otherwise.
     pub fn lab_d65(&self, filter: &dyn Filter) -> CieLab {
-        let xyz0 = self.xyz(&StdIlluminant::D65, Some(filter));
-        xyz0.try_into().unwrap()
+        let xyz = self.xyz(&StdIlluminant::D65, Some(filter));
+        let xyzn = self.xyz_d65();
+        CieLab::new(xyz, xyzn).unwrap()
     }
 
     /// Calculates the L*a*b* CIELAB D50 values of a Colorant, using D65 as an illuminant.
     /// Accepts a Colorant Spectrum only.
     /// Returns f64::NAN's otherwise.
     pub fn lab_d50(&self, filter: &dyn Filter) -> CieLab {
-        let xyz0 = self.xyz(&StdIlluminant::D50, Some(filter));
-        xyz0.try_into().unwrap()
+        let xyz = self.xyz(&StdIlluminant::D50, Some(filter));
+        let xyzn = self.xyz_d50();
+        CieLab::new(xyz, xyzn).unwrap()
     }
 
     /// Returns the wavelength range (in nanometer) for the _horse shoe_,
@@ -378,15 +373,16 @@ impl ObserverData {
     /// Calculates the RGB to XYZ matrix, for a particular color space.
     pub fn rgb2xyz(&self, rgbspace: &RgbSpace) -> Matrix3<f64> {
         let space = rgbspace.data();
-        let mut rgb2xyz = Matrix3::from_iterator(space.primaries.iter().flat_map(|s| {
-            self.xyz_from_spectrum(s, None)
-                .set_illuminance(1.0)
-                .values()
-        }));
+        let mut rgb2xyz = Matrix3::from_iterator(
+            space
+                .primaries
+                .iter()
+                .flat_map(|s| self.xyz_from_spectrum(s).set_illuminance(1.0).values()),
+        );
         let xyzw = self.xyz(&space.white, None).set_illuminance(1.0);
         let decomp = rgb2xyz.lu();
         // unwrap: only used with library color spaces
-        let rgbw = decomp.solve(&xyzw.xyzn).unwrap();
+        let rgbw = decomp.solve(&xyzw.xyz).unwrap();
         for (i, mut col) in rgb2xyz.column_iter_mut().enumerate() {
             col *= rgbw[i];
         }
@@ -567,6 +563,7 @@ mod obs_test {
         approx::assert_ulps_eq!(want, got, epsilon = 3E-4);
     }
 
+    /* not applicable anymore
     #[test]
     fn test_xyz_std_illuminants() {
         use crate::xyz::XYZ;
@@ -579,6 +576,7 @@ mod obs_test {
         approx::assert_ulps_eq!(xyzn, na::Vector3::new(95.04, 100.0, 108.86), epsilon = 1E-2);
         assert!(xyz.is_none());
     }
+     */
 
     #[test]
     fn test_planckian_locus() {
@@ -600,17 +598,19 @@ mod obs_test {
     #[test]
     fn test_xyz_from_illuminant_x_fn() {
         let xyz = CIE1931.xyz_from_std_illuminant_x_fn(&StdIlluminant::D65, |_v| 1.0);
-        let d65xyz = CIE1931.xyz_d65().xyzn;
+        let d65xyz = CIE1931.xyz_d65().xyz;
         approx::assert_ulps_eq!(
             xyz,
-            crate::xyz::XYZ::from_vecs(d65xyz, Some(d65xyz), crate::observer::Observer::Std1931)
+            crate::xyz::XYZ::from_vecs(d65xyz, crate::observer::Observer::Std1931)
         );
     }
 
     #[test]
     fn test_xyz_of_sample_with_standard_illuminant() {
         use crate::prelude::{StdIlluminant::D65 as d65, XYZ};
-        let xyz = CIE1931.xyz(&d65, Some(&crate::colorant::Colorant::white()));
+        let xyz = CIE1931
+            .xyz(&d65, Some(&crate::colorant::Colorant::white()))
+            .set_illuminance(100.0);
         approx::assert_ulps_eq!(xyz, CIE1931.xyz_from_std_illuminant_x_fn(&d65, |_| 1.0));
 
         let xyz = CIE1931.xyz(&d65, Some(&crate::colorant::Colorant::black()));

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -213,17 +213,10 @@ impl Rgb {
     /// Converts the RGB value to a tri-stimulus XYZ value
     pub fn xyz(&self) -> XYZ {
         const YW: f64 = 100.0;
-        let xyzn = self
-            .observer
-            .data()
-            .xyz(&self.space.data().white, None)
-            .set_illuminance(100.0)
-            .xyzn;
         let xyz = self.observer.data().rgb2xyz(&self.space) * self.rgb;
         XYZ {
             observer: self.observer,
-            xyz: Some(xyz.map(|v| v * YW)),
-            xyzn,
+            xyz: xyz.map(|v| v * YW),
         }
     }
 }
@@ -291,7 +284,7 @@ impl Filter for Rgb {
     ///
     /// // Compare with the CIE D65 reference white point
     /// let d65: XYZ = CIE1931.xyz(&StdIlluminant::D65, Some(&rgb));
-    /// approx::assert_ulps_eq!(d65, XYZ_D65WHITE, epsilon = 1e-2);
+    /// approx::assert_ulps_eq!(d65, XYZ_D65, epsilon = 1e-2);
     /// ```
     ///
     /// # Implementation Details

--- a/src/rgbspace.rs
+++ b/src/rgbspace.rs
@@ -267,7 +267,7 @@ mod rgbspace_tests {
             let iter = primaries_chromaticity.into_iter().zip(primaries_colorants);
             for (chromaticity, colorant) in iter {
                 let computed_chromaticity = CIE1931
-                    .xyz_from_spectrum(&colorant.spectrum(), None)
+                    .xyz_from_spectrum(&colorant.spectrum())
                     .chromaticity();
                 assert_ulps_eq!(
                     chromaticity.to_array().as_ref(),

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -619,14 +619,14 @@ mod tests {
     fn test_spectrum_from_rgb() {
         let white: Stimulus = Rgb::new(1.0, 1.0, 1.0, None, None).unwrap().into();
         approx::assert_ulps_eq!(
-            CIE1931.xyz_from_spectrum(&white, None),
+            CIE1931.xyz_from_spectrum(&white),
             CIE1931.xyz_d65().set_illuminance(100.0),
             epsilon = 1E-6
         );
         let red = Stimulus::from_srgb(255, 0, 0);
         assert_ulps_eq!(
             CIE1931
-                .xyz_from_spectrum(&red, None)
+                .xyz_from_spectrum(&red)
                 .chromaticity()
                 .to_array()
                 .as_ref(),
@@ -644,12 +644,12 @@ mod tests {
 
     #[test]
     fn test_chromaticity() {
-        let xyz0 = CIE1931.xyz_from_spectrum(&D65, None);
+        let xyz0 = CIE1931.xyz_from_spectrum(&D65);
         let [x0, y0] = xyz0.chromaticity().to_array();
 
         let illuminance = D65.illuminance(&CIE1931);
         let d65 = D65.clone().set_illuminance(&CIE1931, 100.0);
-        let xyz = CIE1931.xyz_from_spectrum(&d65, None);
+        let xyz = CIE1931.xyz_from_spectrum(&d65);
         let [x, y] = xyz.chromaticity().to_array();
 
         assert_ulps_eq!(x0, x);
@@ -704,10 +704,7 @@ mod tests {
     #[test]
     fn ee() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(
-                &Illuminant::equal_energy().set_illuminance(&CIE1931, 100.0),
-                None,
-            )
+            .xyz_from_spectrum(&Illuminant::equal_energy().set_illuminance(&CIE1931, 100.0))
             .chromaticity();
         assert_ulps_eq!(chromaticity.x(), 0.333_3, epsilon = 5E-5);
         assert_ulps_eq!(chromaticity.y(), 0.333_3, epsilon = 5E-5);
@@ -716,7 +713,7 @@ mod tests {
     #[test]
     fn d65() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(&Illuminant::d65().set_illuminance(&CIE1931, 100.0), None)
+            .xyz_from_spectrum(&Illuminant::d65().set_illuminance(&CIE1931, 100.0))
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.312_72, epsilon = 5E-5);
@@ -734,7 +731,7 @@ mod tests {
     #[test]
     fn d50() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(&Illuminant::d50().set_illuminance(&CIE1931, 100.0), None)
+            .xyz_from_spectrum(&Illuminant::d50().set_illuminance(&CIE1931, 100.0))
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.345_67, epsilon = 5E-5);
@@ -744,7 +741,7 @@ mod tests {
     #[cfg_attr(test, cfg(feature = "cie-illuminants"))]
     fn a() {
         let a: Illuminant = StdIlluminant::A.into();
-        let chromaticity = CIE1931.xyz_from_spectrum(&a, None).chromaticity();
+        let chromaticity = CIE1931.xyz_from_spectrum(&a).chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.447_58, epsilon = 5E-5);
         assert_ulps_eq!(chromaticity.y(), 0.407_45, epsilon = 5E-5);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,7 +19,7 @@ pub trait Light {
     /// The illuminance value is optional, and if not provided, the actual luminous values in the
     /// spectrum are used.
     fn xyzn(&self, observer: Observer, y: Option<f64>) -> XYZ {
-        let xyz = observer.data().xyz_from_spectrum(&self.spectrum(), None);
+        let xyz = observer.data().xyz_from_spectrum(&self.spectrum());
         if let Some(illuminance) = y {
             xyz.set_illuminance(illuminance)
         } else {

--- a/src/widergb.rs
+++ b/src/widergb.rs
@@ -130,17 +130,10 @@ impl WideRgb {
     /// Converts the RGB value to a tri-stimulus XYZ value
     pub fn xyz(&self) -> XYZ {
         const YW: f64 = 100.0;
-        let xyzn = self
-            .observer
-            .data()
-            .xyz(&self.space.data().white, None)
-            .set_illuminance(100.0)
-            .xyzn;
         let xyz = self.observer.data().rgb2xyz(&self.space) * self.rgb;
         XYZ {
             observer: self.observer,
-            xyz: Some(xyz.map(|v| v * YW)),
-            xyzn,
+            xyz: xyz.map(|v| v * YW),
         }
     }
 


### PR DESCRIPTION
I’ve removed the white reference from the `XYZ` struct and updated all the function signatures of the higher-level models (like `CieLab`, `CieCam`, etc.) to take the white reference as an explicit argument.

Please review and check. Still need to update all the documentation...