### PR TITLE
Re-export the error type in the crate root, and rename it to `Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `CieCam16` new takes now an _JCh_ `[f64;3]`-array, a reference white `XYZ` value, and a `ViewConditions` instance.
 - Changed library module structure combining related modules in sub-modules, make the structure less flat, and re-export of most sub-module entities.
 - Renamed `StdIlluminant`-`enum` to `CieIlluminant`
+- Rename `CmtError` to `Error`.
 
 ### Fixed
 - Fix bug `XYZ::set_illuminance`. Avoid divide be zero when luminous values is zero, or negative.

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -46,7 +46,7 @@ use nalgebra::{matrix, vector, Matrix3, SMatrix, Vector3};
 
 use crate::{
     cam::viewconditions::ReferenceValues,
-    error::CmtError,
+    error::Error,
     geometry::distance,
     prelude::Observer,
     traits::{Filter, Light},
@@ -118,11 +118,11 @@ impl CieCam16 {
     /// A Result containing the CieCam16 instance if successful, or a CmtError if an error occurs.
     /// # Errors
     /// Returns an error if the XYZ values are not in the same observer system.
-    pub fn from_xyz(xyz: XYZ, xyzn: XYZ, vc: ViewConditions) -> Result<Self, CmtError> {
+    pub fn from_xyz(xyz: XYZ, xyzn: XYZ, vc: ViewConditions) -> Result<Self, Error> {
         let xyz_vec = xyz.xyz;
         let xyzn_vec = xyzn.xyz;
         if xyz.observer != xyzn.observer {
-            return Err(CmtError::RequireSameObserver);
+            return Err(Error::RequireSameObserver);
         }
         let ReferenceValues {
             n,
@@ -256,9 +256,9 @@ impl CieCam16 {
     ///
     /// # Errors
     /// Returns an error if the observers of the two colors do not match.
-    pub fn ciede2016(&self, other: &Self) -> Result<f64, CmtError> {
+    pub fn ciede2016(&self, other: &Self) -> Result<f64, Error> {
         if self.observer != other.observer {
-            return Err(CmtError::RequireSameObserver);
+            return Err(Error::RequireSameObserver);
         }
 
         let jabp1 = self.jab_prime();
@@ -322,13 +322,13 @@ impl CieCam16 {
         &self,
         white_opt: Option<XYZ>,
         vc_opt: Option<ViewConditions>,
-    ) -> Result<XYZ, CmtError> {
+    ) -> Result<XYZ, Error> {
         let vc = vc_opt.unwrap_or(self.vc);
         let xyzn = if let Some(white) = white_opt {
             if white.observer == self.observer {
                 white.xyz
             } else {
-                return Err(CmtError::RequireSameObserver);
+                return Err(Error::RequireSameObserver);
             }
         } else {
             self.xyzn

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -61,7 +61,7 @@ use approx::{assert_abs_diff_eq, AbsDiffEq};
 use nalgebra::SVector;
 
 use crate::{
-    error::CmtError,
+    error::Error,
     illuminant::CieIlluminant,
     lab::CieLab,
     physics::{gaussian_peak_one, wavelength},
@@ -90,9 +90,9 @@ impl Colorant {
     /// # Errors
     ///
     /// - CmtError::OutOfRange when the spectrum contains values outside the range 0.0 to 1.0.
-    pub fn new(spectrum: Spectrum) -> Result<Self, CmtError> {
+    pub fn new(spectrum: Spectrum) -> Result<Self, Error> {
         if spectrum.values().iter().any(|v| !(0.0..=1.0).contains(v)) {
-            Err(CmtError::OutOfRange {
+            Err(Error::OutOfRange {
                 name: "Colorant Spectral Value".into(),
                 low: 0.0,
                 high: 1.0,
@@ -205,7 +205,7 @@ fn test_colorant_cielab() {
 }
 
 impl TryFrom<Spectrum> for Colorant {
-    type Error = CmtError;
+    type Error = Error;
 
     /// Creates a Colorant from a spectrum, while validating the spectrum values.
     ///

--- a/src/colorant/munsell_matt.rs
+++ b/src/colorant/munsell_matt.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     colorant::munsell_matt::data::{MUNSELL_MATT_DATA, MUNSELL_MATT_KEYS},
-    error::CmtError,
+    error::Error,
     spectrum::{Spectrum, SPECTRUM_WAVELENGTH_RANGE},
     traits::Filter,
 };
@@ -54,11 +54,11 @@ impl MunsellMatt {
     /// Try to find the spectral data for the given key.
     ///
     /// Fails if the key is not found.
-    pub fn try_new(key: String) -> Result<MunsellMatt, CmtError> {
+    pub fn try_new(key: String) -> Result<MunsellMatt, Error> {
         if let Some(&i) = MM_KEY_MAP.get(key.as_str()) {
             Ok(Self::new(i))
         } else {
-            Err(CmtError::SpectrumNotFound(key))
+            Err(Error::SpectrumNotFound(key))
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::JsValue;
 
 #[derive(thiserror::Error, Debug, PartialEq)]
-pub enum CmtError {
+pub enum Error {
     #[error("{name} should be within in range from {low} to {high}")]
     OutOfRange { name: String, low: f64, high: f64 },
     #[error("Error: {0}")]
@@ -44,20 +44,20 @@ pub enum CmtError {
     InvalidRgbValue,
 }
 
-impl From<&str> for CmtError {
+impl From<&str> for Error {
     fn from(s: &str) -> Self {
-        CmtError::ErrorString(s.to_string())
+        Error::ErrorString(s.to_string())
     }
 }
 
-impl From<JsValue> for CmtError {
+impl From<JsValue> for Error {
     fn from(s: JsValue) -> Self {
-        CmtError::ErrorString(s.as_string().expect("Sorry, Unknown Error Encountered"))
+        Error::ErrorString(s.as_string().expect("Sorry, Unknown Error Encountered"))
     }
 }
 
-impl From<CmtError> for JsValue {
-    fn from(value: CmtError) -> Self {
+impl From<Error> for JsValue {
+    fn from(value: Error) -> Self {
         value.to_string().into()
     }
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -3,7 +3,7 @@ use core::f64;
 use nalgebra::ComplexField;
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use crate::error::CmtError;
+use crate::error::Error;
 
 /// Distance of point (x,y) to line going through points (x0,y0) having slope m
 ///
@@ -34,7 +34,7 @@ pub enum Orientation {
 }
 
 impl LineAB {
-    pub fn new(a: [f64; 2], b: [f64; 2]) -> Result<Self, CmtError> {
+    pub fn new(a: [f64; 2], b: [f64; 2]) -> Result<Self, Error> {
         let [[xa, ya], [xb, yb]] = [a, b];
         let l = (xb - xa).hypot(yb - ya);
         let angle = (yb - ya).atan2(xb - xa);
@@ -49,7 +49,7 @@ impl LineAB {
                 angle,
             })
         } else {
-            Err(CmtError::RequiresDistinctPoints)
+            Err(Error::RequiresDistinctPoints)
         }
     }
 
@@ -103,9 +103,9 @@ impl LineAB {
     /// segments, and have a value between 0 and 1 if the intersection is
     /// between the two points used to define the lineAB.
     /// See [Wikipedia](https://en.wikipedia.org/wiki/Line–line_intersection#Given_two_points_on_each_line_segment) for the algorithm used.
-    pub fn intersect(&self, line: &LineAB) -> Result<([f64; 2], f64, f64), CmtError> {
+    pub fn intersect(&self, line: &LineAB) -> Result<([f64; 2], f64, f64), Error> {
         if (self.angle() - line.angle()).abs() < 2.0 * f64::EPSILON {
-            Err(CmtError::NoIntersection)
+            Err(Error::NoIntersection)
         } else {
             let [x1, y1, x2, y2] = [self.xa, self.ya, self.xb, self.yb];
             let [x3, y3, x4, y4] = [line.xa, line.ya, line.xb, line.yb];
@@ -207,7 +207,7 @@ pub struct Triangle {
     nom: f64,
 }
 impl Triangle {
-    pub fn new(a: [f64; 2], b: [f64; 2], c: [f64; 2]) -> Result<Self, CmtError> {
+    pub fn new(a: [f64; 2], b: [f64; 2], c: [f64; 2]) -> Result<Self, Error> {
         let [[xa, ya], [xb, yb], [xc, yc]] = [a, b, c];
         let la = (xc - xb).hypot(yc - yb);
         let lb = (xc - xa).hypot(yc - ya);
@@ -227,7 +227,7 @@ impl Triangle {
                 nom,
             })
         } else {
-            Err(CmtError::RequiresDistinctPoints)
+            Err(Error::RequiresDistinctPoints)
         }
     }
 

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -68,7 +68,7 @@ use wasm_bindgen::prelude::*;
 use nalgebra::{ArrayStorage, SMatrix, SVector};
 
 use crate::{
-    error::CmtError,
+    error::Error,
     illuminant,
     observer::{Observer, ObserverData},
     physics::{gaussian_peak_one, led_ohno, planck, stefan_boltzmann, wavelength},
@@ -220,7 +220,7 @@ impl Illuminant {
     /// - CmtError::OutOfRange when the illuminant's distance to the Planckian locus is larger than 0.05 DUV,
     ///   or when the CCT is outside the range of 1000 to 25000 Kelvin.
     #[cfg(feature = "cri")]
-    pub fn cri(&self) -> Result<CRI, CmtError> {
+    pub fn cri(&self) -> Result<CRI, Error> {
         use cri::CRI;
 
         self.try_into()
@@ -229,9 +229,9 @@ impl Illuminant {
     /// Creates a CIE D Illuminant with a correlated color temperature (CCT) in Kelvin.
     /// # Errors
     /// - CmtError::OutOfRange when the cct argument is below 4000 or above 25000 Kelvin.
-    pub fn d_illuminant(cct: f64) -> Result<Illuminant, CmtError> {
+    pub fn d_illuminant(cct: f64) -> Result<Illuminant, Error> {
         if !(4000.0..=25000.0).contains(&cct) {
-            Err(CmtError::OutOfRange {
+            Err(Error::OutOfRange {
                 name: "CIE D Illuminant Temperature".to_string(),
                 low: 4000.0,
                 high: 25000.0,
@@ -277,7 +277,7 @@ impl Illuminant {
     /// - CmtError::OutOfRange when the the distance to the Planckian locus is larger than 0.05 DUV,
     ///   or when the CCT is outside the range of 1000 to 25000 Kelvin.
     #[cfg(feature = "cct")]
-    pub fn cct(&self) -> Result<cct::CCT, CmtError> {
+    pub fn cct(&self) -> Result<cct::CCT, Error> {
         // CIE requires using the CIE1931 observer for calculating the CCT.
         let xyz = self.xyz(Some(Observer::Std1931));
         cct::CCT::from_xyz(xyz)
@@ -374,7 +374,7 @@ impl Illuminant {
     /// seperately to limit the size of the main web assembly library.
     #[cfg(feature = "cri")]
     #[wasm_bindgen(js_name=cri)]
-    pub fn cri_js(&self) -> Result<crate::cri::CRI, CmtError> {
+    pub fn cri_js(&self) -> Result<crate::cri::CRI, Error> {
         todo!()
     }
 

--- a/src/illuminant/cie_illuminant.rs
+++ b/src/illuminant/cie_illuminant.rs
@@ -39,7 +39,7 @@
 //! ```
 
 use crate::{
-    error::CmtError, illuminant::Illuminant, spectrum::Spectrum, spectrum::NS, traits::Light,
+    error::Error, illuminant::Illuminant, spectrum::Spectrum, spectrum::NS, traits::Light,
 };
 use nalgebra::{ArrayStorage, SMatrix};
 use std::{borrow::Cow, ops::Deref, vec};

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     colorant::Colorant,
-    error::CmtError,
+    error::Error,
     illuminant::Illuminant,
     observer::CIE1931,
     rgb::RgbSpace,
@@ -84,7 +84,7 @@ fn tcs_test() {
 pub struct CRI([f64; N_TCS]);
 
 impl CRI {
-    pub fn new(s: impl AsRef<Illuminant>) -> Result<Self, CmtError> {
+    pub fn new(s: impl AsRef<Illuminant>) -> Result<Self, Error> {
         s.as_ref().try_into()
     }
 
@@ -110,7 +110,7 @@ impl Index<usize> for CRI {
 /// Can fail, for example if the Spectrum's correlated color temperature is out of range.
 /// Uses CIE1931, and requires "cct"-feature.
 impl TryFrom<&Illuminant> for CRI {
-    type Error = CmtError;
+    type Error = Error;
 
     fn try_from(illuminant: &Illuminant) -> Result<Self, Self::Error> {
         let illuminant = &illuminant.clone().set_illuminance(&CIE1931, 100.0);

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -49,7 +49,7 @@ use approx::ulps_eq;
 use nalgebra::{RowVector3, Vector3};
 use std::f64::consts::PI;
 
-use crate::{error::CmtError, prelude::Observer, xyz::XYZ};
+use crate::{error::Error, prelude::Observer, xyz::XYZ};
 use strum_macros::Display;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -86,9 +86,9 @@ impl CieLab {
     ///
     /// # Returns
     /// A `Result` containing the CIE L*a*b* color or an error if the observers do not match.
-    pub fn from_xyz(xyz: XYZ, xyzn: XYZ) -> Result<CieLab, CmtError> {
+    pub fn from_xyz(xyz: XYZ, xyzn: XYZ) -> Result<CieLab, Error> {
         if xyz.observer != xyzn.observer {
-            Err(CmtError::RequireSameObserver)
+            Err(Error::RequireSameObserver)
         } else {
             Ok(CieLab {
                 observer: xyz.observer,
@@ -127,16 +127,16 @@ impl CieLab {
     /// let de = lab1.ciede(&lab2).unwrap();
     /// approx::assert_abs_diff_eq!(de, 6.57, epsilon = 0.01);
     /// ```
-    pub fn ciede(&self, other: &Self) -> Result<f64, CmtError> {
+    pub fn ciede(&self, other: &Self) -> Result<f64, Error> {
         if self.observer != other.observer {
-            return Err(CmtError::RequireSameObserver);
+            return Err(Error::RequireSameObserver);
         }
         if ulps_eq!(self.xyzn, other.xyzn) {
             let &[l1, a1, b1] = self.lab.as_ref();
             let &[l2, a2, b2] = other.lab.as_ref();
             Ok(((l2 - l1).powi(2) + (a2 - a1).powi(2) + (b2 - b1).powi(2)).sqrt())
         } else {
-            Err(CmtError::RequiresSameIlluminant)
+            Err(Error::RequiresSameIlluminant)
         }
     }
 
@@ -167,14 +167,14 @@ impl CieLab {
     /// let de = lab1.ciede2000(&lab2).unwrap();
     /// approx::assert_abs_diff_eq!(de, 1.2644, epsilon = 1E-4);
     /// ```
-    pub fn ciede2000(&self, other: &Self) -> Result<f64, CmtError> {
+    pub fn ciede2000(&self, other: &Self) -> Result<f64, Error> {
         if self.observer != other.observer {
-            return Err(CmtError::RequireSameObserver);
+            return Err(Error::RequireSameObserver);
         }
         if ulps_eq!(self.xyzn, other.xyzn) {
             Ok(delta_e_ciede2000(self.lab, other.lab))
         } else {
-            Err(CmtError::RequiresSameIlluminant)
+            Err(Error::RequiresSameIlluminant)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod cam;
 pub mod colorant;
-pub mod error;
+mod error;
 pub mod geometry;
 pub mod illuminant;
 pub mod lab;
@@ -20,3 +20,5 @@ pub mod spectrum;
 pub mod stimulus;
 pub mod traits;
 pub mod xyz;
+
+pub use error::CmtError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,4 +21,4 @@ pub mod stimulus;
 pub mod traits;
 pub mod xyz;
 
-pub use error::CmtError;
+pub use error::Error;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -48,7 +48,7 @@ pub use observers::*;
 
 use crate::{
     colorant::Colorant,
-    error::CmtError,
+    error::Error,
     geometry::LineAB,
     illuminant::CieIlluminant,
     lab::CieLab,
@@ -196,9 +196,9 @@ impl ObserverData {
     /// However, please read the documentation for the
     /// [`spectral_locus_wavelength_range`](Self::spectral_locus_wavelength_range) method on
     /// situations where you might not want to sample the full range.
-    pub fn xyz_at_wavelength(&self, wavelength: usize) -> Result<XYZ, CmtError> {
+    pub fn xyz_at_wavelength(&self, wavelength: usize) -> Result<XYZ, Error> {
         if !SPECTRUM_WAVELENGTH_RANGE.contains(&wavelength) {
-            return Err(CmtError::WavelengthOutOfRange);
+            return Err(Error::WavelengthOutOfRange);
         };
         let &[x, y, z] = self
             .data

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -61,7 +61,7 @@ pub use widergb::WideRgb;
 
 use crate::{
     colorant::Colorant,
-    error::CmtError,
+    error::Error,
     illuminant::Illuminant,
     observer::Observer,
     observer::CIE1931,
@@ -138,7 +138,7 @@ impl Rgb {
         b: f64,
         opt_observer: Option<Observer>,
         opt_rgbspace: Option<RgbSpace>,
-    ) -> Result<Self, CmtError> {
+    ) -> Result<Self, Error> {
         if (0.0..=1.0).contains(&r) && (0.0..=1.0).contains(&g) && (0.0..=1.0).contains(&b) {
             let observer = opt_observer.unwrap_or_default();
             let space = opt_rgbspace.unwrap_or_default();
@@ -148,7 +148,7 @@ impl Rgb {
                 space,
             })
         } else {
-            Err(CmtError::InvalidRgbValue)
+            Err(Error::InvalidRgbValue)
         }
     }
 


### PR DESCRIPTION
The purpose of this PR was primarily to hide the `error` module and re-export the one and only type it contained in the crate root instead. This does not cause the crate root to have a larger API surface (replace one module for one type) and it provides easier access to this one type that is used all over the place.

I also decided to suggest renaming `CmtError` to just `Error`. It's very common that a library that has one error type it collects everything that can go wrong into just calls it `Error`. It still has more information in the full path `colorimetry::Error`. And anyone using it in an already clobbered namespace can either refer to it by it's full (but still pretty short) path, or they can import it with a rename `use colorimetry::Error as ColorimetryError` if they prefer.