### PR TITLE
Observer update (see #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Refactored `physics.rs` with the planck functions and LED functions now moved to the `Illuminant` module,
   and the remaining functions combined with teh `geometry.rs` functions into `math.rs`.
 - Changed `stefan_boltzmann` method name to `total_radiance`.
-
+- Renamed `ObserverData::xyz_fn_illuminant` to `xyz_from_fn`.
+- Renamed `ObserverData::xyz_from_std_illuminant_x_fn` to `xyz_from_colorant_fn`.
 ### Removed
 - Various normal distribution (gaussian) helper functions, now all collected as methods of the `Gaussian` struct.
 - Various Planck's law helper functions, now all collected as methods of the `Planck` struct.


### PR DESCRIPTION
- Renaming and updating  documentation `xyz_from_std_illuminant_x_fn` and `xyz_fn_illuminant`, and moving them to the bottom of the `impl` block.
- Also taking a look at buffering xyz_d65 and xyz_d50