### PR TITLE
Remove dead_code from global crate lint allow list

### DIFF
--- a/src/cam.rs
+++ b/src/cam.rs
@@ -226,39 +226,43 @@ fn inv_cone_adaptation(f_l: f64, x: f64) -> f64 {
     x.signum() * ((100.0 * t.powf(1.0 / 0.42)) / f_l)
 }
 
+#[allow(dead_code)]
 const MCAT02: SMatrix<f64, 3, 3> = matrix![
      0.7328,  0.4296,  -0.1624;
     -0.7036,  1.6975,   0.0061;
      0.0030,  0.0136,   0.9834;
 ];
 
-/**
-   Inverse CIECAT02 Chromatic Adaptation as a Matrix
-*/
+/// Inverse CIECAT02 Chromatic Adaptation as a Matrix
+#[allow(dead_code)]
 const MCAT02INV: SMatrix<f64, 3, 3> = matrix![
     1.096123820835514, 		-0.2788690002182872, 	0.18274517938277304;
     0.45436904197535916,	 0.4735331543074117,	0.0720978037172291;
     -0.009627608738429353, 	-0.005698031216113419,	1.0153256399545427;
 ];
 
+#[allow(dead_code)]
 const MHPE: SMatrix<f64, 3, 3> = matrix![
      0.38971, 0.68898, -0.07868;
     -0.22981, 1.18340,  0.04641;
      0.00000, 0.00000,  1.00000;
 ];
 
+#[allow(dead_code)]
 const MHPEINVLUO: SMatrix<f64, 3, 3> = matrix![
     1.910197, -1.112124,  0.201908;
     0.370950,  0.629054, -0.000008;
     0.000000,  0.000000,  1.000000;
 ];
 
+#[allow(dead_code)]
 const MHPEINV: SMatrix<f64, 3, 3> = matrix![
     1.9101968340520348, -1.1121238927878747,  0.20190795676749937;
     0.3709500882486886,  0.6290542573926132, -0.000008055142184359149;
     0.0,  				 0.0,  				  1.0;
 ];
 
+#[allow(dead_code)]
 const MCAT02INVLUO: SMatrix<f64, 3, 3> = matrix![
      1.096124, -0.278869, 0.182745;
      0.454369,  0.473533, 0.072098;

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -270,6 +270,7 @@ const M16INV: Matrix3<f64> = matrix![
     -0.01584150, -0.03412294, 1.04996444
 ];
 
+#[allow(dead_code)]
 const MRGBAINV: Matrix3<f64> = matrix![
    460.0/C16_3, 451.0/C16_3, 288.0/C16_3;
    460.0/C16_3, -891.0/C16_3, -261.0/C16_3;

--- a/src/cam/viewconditions.rs
+++ b/src/cam/viewconditions.rs
@@ -102,6 +102,7 @@ impl Default for ViewConditions {
     }
 }
 
+#[allow(dead_code)]
 pub const TM30VC: ViewConditions = ViewConditions {
     yb: 20.0,
     c: 0.69,
@@ -112,6 +113,7 @@ pub const TM30VC: ViewConditions = ViewConditions {
 };
 
 /// Values according to Table 1, record 2, CIE 248:2022
+#[allow(dead_code)]
 pub const CIE_HOME_DISPLAY: ViewConditions = ViewConditions {
     yb: 20.0,
     c: 0.59,

--- a/src/colorant/munsell_matt.rs
+++ b/src/colorant/munsell_matt.rs
@@ -23,6 +23,7 @@ use crate::{
 pub(crate) const MATT_N: usize = 81;
 pub(crate) const MATT_M: usize = 1269;
 
+#[allow(dead_code)]
 #[wasm_bindgen]
 pub struct MunsellMatt(String, Spectrum);
 

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -174,12 +174,12 @@ fn uv_kries(cdt: [f64; 2], cdr: [f64; 2], cdti: [f64; 2]) -> [f64; 2] {
 
 #[cfg(test)]
 mod cri_test {
-    use crate::illuminant::{CieIlluminant, CRI, D50};
+    use crate::illuminant::{CRI, D50};
 
     #[test]
     fn cri_d50() {
         // should be all 100.0
-        let cri0: crate::illuminant::CRI = (&D50).try_into().unwrap();
+        let cri0: CRI = (&D50).try_into().unwrap();
         // println!("{cri0:?}");
         approx::assert_ulps_eq!(
             cri0.as_ref(),
@@ -191,16 +191,22 @@ mod cri_test {
     #[test]
     #[cfg(feature = "cie-illuminants")]
     fn cri_f1() {
+        use crate::illuminant::CieIlluminant;
         // should be all 100.0
 
         let cri0: CRI = CieIlluminant::F1.illuminant().try_into().unwrap();
         println!("{cri0:?}");
-        // approx::assert_ulps_eq!(cri0.as_ref(), [100.0;crate::cri::N_TCS].as_ref(), epsilon = 0.05);
+        // approx::assert_ulps_eq!(
+        //     cri0.as_ref(),
+        //     [100.0; crate::illuminant::cri::N_TCS].as_ref(),
+        //     epsilon = 0.05
+        // );
     }
 
     #[test]
     #[cfg(feature = "cie-illuminants")]
     fn cri_f3_1() {
+        use crate::illuminant::CieIlluminant;
         // 2932K, check with values as given in CIE15:2004 Table T.8.2
         let cri0: CRI = CieIlluminant::F3_1.illuminant().try_into().unwrap();
         approx::assert_ulps_eq!(
@@ -215,6 +221,7 @@ mod cri_test {
     #[test]
     #[cfg(feature = "cie-illuminants")]
     fn cri_f3_11() {
+        use crate::illuminant::CieIlluminant;
         // 5854K, check with values as given in CIE15:2004 Table T.8.2
         let cri0: CRI = CRI::new(CieIlluminant::F3_11).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unused_variables, unused_imports)]
+#![allow(unused_variables)]
 #![doc = include_str!("../README.md")]
 // This library defines many floating-point constants for colorimetry.
 // Clippy's `approx_constant` lint would otherwise generate numerous false positives

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -709,15 +709,6 @@ mod tests {
         assert_ulps_eq!(chromaticity.y(), 0.358_51, epsilon = 5E-5);
     }
 
-    #[cfg_attr(test, cfg(feature = "cie-illuminants"))]
-    fn a() {
-        let a: Illuminant = CieIlluminant::A.into();
-        let chromaticity = CIE1931.xyz_from_spectrum(a.as_ref()).chromaticity();
-        // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
-        assert_ulps_eq!(chromaticity.x(), 0.447_58, epsilon = 5E-5);
-        assert_ulps_eq!(chromaticity.y(), 0.407_45, epsilon = 5E-5);
-    }
-
     #[test]
     fn add_spectra() {
         use approx::assert_ulps_eq;


### PR DESCRIPTION
Explicitly allowing some dead code that is not yet used. I was balancing between adding explicit `#[allow(dead_code)]` (like in this PR and commenting out said code or deleting it. But given that these are likely things you want to use soon, and that the following solution allows for the code to still be checked in the CI during development, I opted for this solution :) If you don't think these things will be used at all or soon, we can also consider deleting them.

Having `#![allow(dead_code)]` on a global crate level has the downside of making it easy to forget old code laying around after doing refactoring and other stuff. So if possible, it would be nice to not allow it globally. Some of these lint allowances might have made it easier during some early prototyping/refactoring. But I think it does way more harm than good on the `main` branch, where we want the code to be clean and tidy.
