### PR TITLE
Forbid unused variables

### DIFF
--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -106,8 +106,6 @@ impl CieCam16 {
             aw,
             qu,
         } = cam.reference_values();
-        let vcdd = vc.dd();
-        let vcfl = vc.f_l();
         let mut rgb = M16 * xyz_vec;
         rgb.component_mul_assign(&Vector3::from(d_rgb));
         rgb.apply(|v| vc.lum_adapt(v, 0.26, qu));
@@ -182,7 +180,8 @@ impl CieCam16 {
         vc_opt: Option<ViewConditions>,
     ) -> Result<XYZ, Error> {
         let vc = vc_opt.unwrap_or_default();
-        let xyzn = if let Some(white) = white_opt {
+        // TODO: Use this
+        let _xyzn = if let Some(white) = white_opt {
             if white.observer == self.observer() {
                 white.xyz
             } else {
@@ -198,7 +197,7 @@ impl CieCam16 {
             ncb,
             d_rgb,
             aw,
-            qu,
+            qu: _gu,
         } = self.reference_values();
         let d_rgb_vec = Vector3::from(d_rgb);
         let &[lightness, chroma, hue_angle] = self.jch_vec().as_ref();

--- a/src/colorant/tcs.rs
+++ b/src/colorant/tcs.rs
@@ -36,7 +36,6 @@ pub static TCS: LazyLock<[Colorant; N_TCS]> = LazyLock::new(|| {
 #[test]
 fn tcs_test() {
     use crate::observer::CIE1931;
-    let xyzn = CIE1931.xyz_d65();
     for (i, s) in TCS.iter().enumerate() {
         let xyz = CIE1931.xyz(&crate::illuminant::CieIlluminant::D65, Some(s));
         let [r, g, b]: [u8; 3] = xyz.rgb(Some(crate::rgb::RgbSpace::SRGB)).clamp().into();

--- a/src/illuminant/cct.rs
+++ b/src/illuminant/cct.rs
@@ -210,7 +210,6 @@ impl TryFrom<XYZ> for CCT {
         if imlow == 0 {
             // xyz is in the first interval, or above high temperature limit
             let &[ub, vb, m] = robertson_table(imlow);
-            let d = distance_to_line(u, v, ub, vb, m);
             match distance_to_line(u, v, ub, vb, m) {
                 d if ulps_eq!(d, 0.0, epsilon = 1E-10) => {
                     // at low temp limit
@@ -397,17 +396,14 @@ mod tests {
 
         // Get a CCT to test. Unwrap OK as range restricted above.
         let cct0 = CCT::new(t, d).unwrap();
-
         // calculate XYZ0, skip value if not a valid point
-        let Ok(xyz0): Result<XYZ, _> = CCT::new(t, d).unwrap().try_into() else {
-            return None;
-        };
+        let xyz0 = XYZ::try_from(cct0).ok()?;
 
         // calculate the cct to test.
-        let cct: CCT = xyz0.try_into().unwrap();
+        let cct: CCT = CCT::try_from(xyz0).unwrap();
 
         // calculate XYZ, should not fail, a CCT and Duv very close to already fetted values.
-        let xyz: XYZ = cct.try_into().unwrap();
+        let xyz = XYZ::try_from(cct).unwrap();
         let d_uv = xyz.uv_prime_distance(&xyz0);
         Some(d_uv)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unused_variables)]
 #![doc = include_str!("../README.md")]
 // This library defines many floating-point constants for colorimetry.
 // Clippy's `approx_constant` lint would otherwise generate numerous false positives

--- a/src/math.rs
+++ b/src/math.rs
@@ -142,7 +142,6 @@ impl LineAB {
     }
 
     pub fn orientation(&self, x: f64, y: f64) -> Orientation {
-        let n = self.nom(x, y);
         match self.nom(x, y) {
             d if d > f64::EPSILON => Orientation::Left,
             d if d < -f64::EPSILON => Orientation::Right,

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -252,8 +252,11 @@ impl ObserverData {
     /// let cie1931_d50_xyz = colorimetry::observer::CIE1931.xyz_d50();
     /// approx::assert_ulps_eq!(cie1931_d50_xyz.values().as_ref(), [96.421, 100.0, 82.519].as_ref(), epsilon = 5E-2);
     ///
+    /// # #[cfg(feature = "supplemental-observers")]
+    /// # {
     /// let cie1964_d50_xyz = colorimetry::observer::CIE1964.xyz_d50();
     /// approx::assert_ulps_eq!(cie1964_d50_xyz.values().as_ref(), [96.720, 100.0, 81.427].as_ref(), epsilon = 5E-2);
+    /// # }
     /// ```
     pub fn xyz_d50(&self) -> XYZ {
         *self.d50.get_or_init(|| {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -552,7 +552,7 @@ mod obs_test {
             for wavelength in observer.data().spectral_locus_wavelength_range() {
                 let xyz = observer.data().xyz_at_wavelength(wavelength).unwrap();
                 for rgbspace in RgbSpace::iter() {
-                    let rgb = xyz.rgb(Some(rgbspace));
+                    let _rgb = xyz.rgb(Some(rgbspace));
                 }
             }
         }

--- a/src/rgb/gamma.rs
+++ b/src/rgb/gamma.rs
@@ -70,11 +70,13 @@ impl GammaCurve {
                 x.powf(1.0 / g)
             }
             3 => {
-                let [g, a, b] = self.p[..] else { panic!() }; // never reached
+                let [_g, _a, _b] = self.p[..] else { panic!() }; // never reached
                 todo!()
             }
             4 => {
-                let [g, a, b, c] = self.p[..] else { panic!() };
+                let [_g, _a, _b, _c] = self.p[..] else {
+                    panic!()
+                };
                 todo!()
             }
             5 => {
@@ -88,7 +90,7 @@ impl GammaCurve {
                 }
             }
             7 => {
-                let [g, a, b, c, d, e, f] = self.p[..] else {
+                let [_g, _a, _b, _c, _d, _e, _f] = self.p[..] else {
                     panic!()
                 };
                 todo!()

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -614,7 +614,6 @@ mod tests {
         let xyz0 = CIE1931.xyz_from_spectrum(D65.as_ref());
         let [x0, y0] = xyz0.chromaticity().to_array();
 
-        let illuminance = D65.illuminance(&CIE1931);
         let d65 = D65.clone().set_illuminance(&CIE1931, 100.0);
         let xyz = CIE1931.xyz_from_spectrum(d65.as_ref());
         let [x, y] = xyz.chromaticity().to_array();
@@ -802,15 +801,10 @@ mod tests {
         //  let sigma = sigma_from_fwhm(5.0);
         let w = Colorant::gaussian(550.0, sigma);
         let scale = sigma * (PI * 2.0).sqrt(); // integral of a gaussian
-        s.0.iter()
-            .zip(w.0 .0.iter())
-            .enumerate()
-            .for_each(|(i, (s, w))| {
-                let j = i + 380;
-                let w = w / scale; // change the reference gaussian colorant to have an integral of 1.0
-                                   //println!("{j} {s:.6} {w:.6}");
-                approx::assert_abs_diff_eq!(s, &w, epsilon = 1E-8);
-            });
+        s.0.iter().zip(w.0 .0.iter()).for_each(|(s, w)| {
+            let w = w / scale; // change the reference gaussian colorant to have an integral of 1.0
+            approx::assert_abs_diff_eq!(s, &w, epsilon = 1E-8);
+        });
     }
 
     #[test]
@@ -856,8 +850,6 @@ mod tests {
         tinterpolate.iter().enumerate().for_each(|(i, &v)| {
             let x = i as f64 / 400.0;
             let y = (x * PI).sin();
-            let d = (y - v).abs();
-            //  println!("{i} {y:.4} {v:.4} {d:.6}");
             approx::assert_ulps_eq!(y, v, epsilon = 4E-3)
         });
         // non boundary points have very high accuracy
@@ -882,7 +874,6 @@ mod tests {
         let mut data = vec![0.0, 1.0, 0.0];
         let mut wl = vec![380.0, 480.0, 780.0];
         let mut spd = linterp_irr(&wl, &data).unwrap();
-        // println!("{:?}", spd);
         assert_ulps_eq!(spd[0], 0.);
         assert_ulps_eq!(spd[50], 0.5);
         assert_ulps_eq!(spd[100], 1.0);
@@ -893,7 +884,6 @@ mod tests {
         data = vec![0.0, 1.0, 1.0, 0.0];
         wl = vec![480.0, 490.0, 570.0, 580.0];
         spd = linterp_irr(&wl, &data).unwrap();
-        // println!("{:?}", spd);
         assert_ulps_eq!(spd[0], 0.0);
         assert_ulps_eq!(spd[100], 0.0);
         assert_ulps_eq!(spd[110], 1.0);

--- a/src/xyz/dominant.rs
+++ b/src/xyz/dominant.rs
@@ -166,7 +166,7 @@ mod xyz_test {
             let chromaticity = sl.chromaticity();
             let line_u =
                 LineAB::new(chromaticity.to_array(), white_chromaticity.to_array()).unwrap();
-            let ([xi, yi], t, _) = line_t.intersect(&line_u).unwrap();
+            let ([_xi, yi], t, _) = line_t.intersect(&line_u).unwrap();
             if t > 0.0 && t < 1.0 {
                 // see https://en.wikipedia.org/wiki/CIE_1931_color_space#Mixing_colors_specified_with_the_CIE_xy_chromaticity_diagram
                 let b = xyzb.set_illuminance(100.0 * (yb * (yr - yi)));


### PR DESCRIPTION
Follow up to #77. Stops disabling great lints by default. As shown by the diff here, disabling this lint caused a lot of unused code to sit around. IMHO this just does harm. Makes the code harder to read and clutter up the library.

In the cam16 module I left the code sit with a `_` prefix in some places. Because here I thought it was unused because you just were working on an implementation and did not finish yet. So I figured it might be a step backwards to remove it again just now.