### PR TITLE
Hardcode spectral locus range to simplify and speed up code

### DIFF
--- a/examples/spectral_locus.rs
+++ b/examples/spectral_locus.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for observer in Observer::iter() {
         let wavelength_range = observer.data().spectral_locus_wavelength_range();
         println!(
-            "Spectral locus for {observer:?} goes from {} to {}",
+            "Spectral locus for {observer} goes from {} to {}",
             wavelength_range.start(),
             wavelength_range.end()
         );

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -70,7 +70,7 @@ use strum_macros::EnumIter;
 */
 #[cfg(not(feature = "supplemental-observers"))]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
-#[derive(Clone, Copy, Default, PartialEq, Eq, Debug, EnumIter)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Debug, EnumIter)]
 pub enum Observer {
     #[default]
     Std1931,
@@ -78,7 +78,7 @@ pub enum Observer {
 
 #[cfg(feature = "supplemental-observers")]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
-#[derive(Clone, Copy, Default, PartialEq, Eq, Debug, EnumIter)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Debug, EnumIter)]
 pub enum Observer {
     #[default]
     Std1931,

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -58,7 +58,7 @@ use crate::{
     xyz::XYZ,
 };
 use nalgebra::{Matrix3, SMatrix, Vector3};
-use std::{ops::RangeInclusive, sync::OnceLock};
+use std::{fmt, ops::RangeInclusive, sync::OnceLock};
 use strum_macros::EnumIter;
 
 /**
@@ -104,6 +104,12 @@ impl Observer {
     }
 }
 
+impl fmt::Display for Observer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.data().name().fmt(f)
+    }
+}
+
 /**
     A data structure to define Standard Observers, such as the CIE 1931 2º and
     the CIE 2015 standard observers.
@@ -128,6 +134,7 @@ pub struct ObserverData {
     data: SMatrix<f64, 3, NS>,
     lumconst: f64,
     tag: Observer,
+    name: &'static str,
     d65: OnceLock<XYZ>,
     d50: OnceLock<XYZ>,
 
@@ -142,15 +149,26 @@ impl ObserverData {
     ///
     /// Only visible to the crate itself since it cannot be used nicely from the outside
     /// (since the `tag` is not something anyone else can create new varians of).
-    pub(crate) const fn new(tag: Observer, lumconst: f64, data: SMatrix<f64, 3, NS>) -> Self {
+    pub(crate) const fn new(
+        tag: Observer,
+        name: &'static str,
+        lumconst: f64,
+        data: SMatrix<f64, 3, NS>,
+    ) -> Self {
         Self {
             data,
             lumconst,
             tag,
+            name,
             d65: OnceLock::new(),
             d50: OnceLock::new(),
             spectral_locus_range: OnceLock::new(),
         }
+    }
+
+    /// Returns the name of the observer.
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
     /// Calulates Tristimulus values for an object implementing the [Light] trait, and an optional [Filter],

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -7,6 +7,7 @@ use crate::{
 
 pub static CIE1931: ObserverData = ObserverData::new(
     Observer::Std1931,
+    "CIE 1931 2° Standard Observer",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.001368, 0.000039, 0.006450001],
@@ -416,6 +417,7 @@ pub static CIE1931: ObserverData = ObserverData::new(
 #[cfg(feature = "supplemental-observers")]
 pub static CIE1964: ObserverData = ObserverData::new(
     Observer::Std1964,
+    "CIE 1964 10° Standard Observer",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.000159952, 0.000017364, 0.000704776],
@@ -825,6 +827,7 @@ pub static CIE1964: ObserverData = ObserverData::new(
 #[cfg(feature = "supplemental-observers")]
 pub static CIE2015: ObserverData = ObserverData::new(
     Observer::Std2015,
+    "CIE 2015 2° cone-fundamental-based observer",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.0, 0.0, 0.0],
@@ -1257,6 +1260,7 @@ pub static CIE2015: ObserverData = ObserverData::new(
 /// are encountered.
 pub static CIE2015_10: ObserverData = ObserverData::new(
     Observer::Std2015_10,
+    "CIE 2015 10° cone-fundamental-based observer",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.000000E+00, 0.000000E+00, 0.000000E+00],

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -7,7 +7,7 @@ use crate::{
 
 pub static CIE1931: ObserverData = ObserverData::new(
     Observer::Std1931,
-    "CIE 1931 2° Standard Observer",
+    "CIE 1931 2°",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.001368, 0.000039, 0.006450001],
@@ -417,7 +417,7 @@ pub static CIE1931: ObserverData = ObserverData::new(
 #[cfg(feature = "supplemental-observers")]
 pub static CIE1964: ObserverData = ObserverData::new(
     Observer::Std1964,
-    "CIE 1964 10° Standard Observer",
+    "CIE 1964 10°",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.000159952, 0.000017364, 0.000704776],
@@ -827,7 +827,7 @@ pub static CIE1964: ObserverData = ObserverData::new(
 #[cfg(feature = "supplemental-observers")]
 pub static CIE2015: ObserverData = ObserverData::new(
     Observer::Std2015,
-    "CIE 2015 2° cone-fundamental-based observer",
+    "CIE 2015 2°",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.0, 0.0, 0.0],
@@ -1260,7 +1260,7 @@ pub static CIE2015: ObserverData = ObserverData::new(
 /// are encountered.
 pub static CIE2015_10: ObserverData = ObserverData::new(
     Observer::Std2015_10,
-    "CIE 2015 10° cone-fundamental-based observer",
+    "CIE 2015 10°",
     683.0,
     SMatrix::<f64, 3, NS>::from_array_storage(ArrayStorage([
         [0.000000E+00, 0.000000E+00, 0.000000E+00],

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -16,7 +16,7 @@ const D65X: f64 = 0.312_738;
 const D65Y: f64 = 0.329_052;
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
-#[derive(Debug, Clone, Copy, Default, EnumIter, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, EnumIter)]
 /**
 A Light Weight tag, representing an RGB color space.
 Used for example in the RGB value set, to identify the color space being used.

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::OnceLock;
 
 use crate::xyz::Chromaticity;
@@ -82,6 +83,12 @@ impl RgbSpace {
             Self::ADOBE => CieIlluminant::D65,
             Self::DisplayP3 => CieIlluminant::D65,
         }
+    }
+}
+
+impl fmt::Display for RgbSpace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
     }
 }
 


### PR DESCRIPTION
The color matching function data is fixed. The computation of the spectral locus range only depend on this fixed data. The spectral locus min/max range will always be the same. So computing it at runtime for every new process that runs this library is a waste. And guarding every single access to the range behind a thread safe init check is a waste. I have looked a little bit into trying to make the computation a `const fn` so we could compute it at compile time. But Rust is not there yet. A lot of trigonometry would need to be const for example, and it just isn't.

So the backup solution that this PR proposes is to hardcode these known ranges, and verify they are correct via tests. This allows getting rid of the `OnceLock` as well as the need for computing this fixed range on first use at runtime. This both simplifies the code and should give better performance.

I envision we could do something similar for some of the other "buffered" values. But one thing at a time. If we can do it for the spectral locus range for now then that's a good start.

Again, this work builds on top of another feature branch (#80) so this PR contains commits that it shouldn't. This workflow isn't ideal, but I don't know of a better one on github. To see what this PR tries to do, just look at the last commit only.