### PR TITLE
Replace all API `&ObserverData` types with `Observer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed `stefan_boltzmann` method name to `total_radiance`.
 - Renamed `ObserverData::xyz_fn_illuminant` to `xyz_from_fn`.
 - Renamed `ObserverData::xyz_from_std_illuminant_x_fn` to `xyz_from_colorant_fn`.
+- Replaced all instances of `&ObserverData` in the public API with `Observer`, which is an `enum`, to avoid confusion between the use of `ObserverData` and `Observer`.
 
 ### Removed
 - Various normal distribution (gaussian) helper functions, now all collected as methods of the `Gaussian` struct.

--- a/src/cam/cam02.rs
+++ b/src/cam/cam02.rs
@@ -17,8 +17,8 @@
 //! use colorimetry::cam::CamTransforms;
 //! use colorimetry::observer::Observer;
 //!
-//! let sample = XYZ::new([60.7, 49.6, 10.3], Observer::Std1931);
-//! let white  = XYZ::new([96.46, 100.0, 108.62], Observer::Std1931);
+//! let sample = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
+//! let white  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
 //! let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
 //!
 //! let cam = CieCam02::from_xyz(sample, white, vc).unwrap();
@@ -123,8 +123,8 @@ impl CieCam02 {
     /// use colorimetry::xyz::XYZ;
     /// use colorimetry::observer::Observer;
     /// // Original CAM16 instance:
-    /// let sample_xyz = XYZ::new([60.7, 49.6, 10.3], Observer::Std1931);
-    /// let white_xyz  = XYZ::new([96.46, 100.0, 108.62], Observer::Std1931);
+    /// let sample_xyz = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
+    /// let white_xyz  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
     /// let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
     /// let cam = CieCam02::from_xyz(sample_xyz, white_xyz, vc).unwrap();
     ///
@@ -132,7 +132,7 @@ impl CieCam02 {
     /// let back_to_xyz = cam.xyz(None, None).unwrap();
     ///
     /// // Inverse with a new white point:
-    /// let new_white = XYZ::new([95.0, 100.0, 108.0], Observer::Std1931);
+    /// let new_white = XYZ::new([95.0, 100.0, 108.0], Observer::Cie1931);
     /// let adapted_xyz = cam.xyz(Some(new_white), None).unwrap();
     /// ```
     pub fn xyz(
@@ -184,8 +184,8 @@ mod cam02_test {
     // Worked example from CIECAM02 documentation, CIE159:2004, p. 11
     fn test_worked_example() {
         // forward transform (XYZ -> JCh)
-        let xyz = XYZ::new([19.31, 23.93, 10.14], Observer::Std1931);
-        let xyzn = XYZ::new([98.88, 90.0, 32.03], Observer::Std1931);
+        let xyz = XYZ::new([19.31, 23.93, 10.14], Observer::Cie1931);
+        let xyzn = XYZ::new([98.88, 90.0, 32.03], Observer::Cie1931);
 
         // Table 4, column 2, CIE 159:2004.
         // La = 20 cd/m2;
@@ -241,7 +241,7 @@ mod cam02_round_trip_tests {
 
         for &xyz_arr in samples {
             // forward transform (XYZ -> JCh)
-            let xyz = XYZ::new(xyz_arr, Observer::Std1931);
+            let xyz = XYZ::new(xyz_arr, Observer::Cie1931);
             let xyz_d65 = CIE1931.xyz_d65();
             let cam = CieCam02::from_xyz(xyz, xyz_d65, ViewConditions::default()).unwrap();
             let jch = cam.jch();
@@ -251,7 +251,7 @@ mod cam02_round_trip_tests {
             let xyz_back = cam_back.xyz(None, None).unwrap();
 
             // compare original vs. round-tripped XYZ
-            let orig = XYZ::new(xyz_arr, Observer::Std1931);
+            let orig = XYZ::new(xyz_arr, Observer::Cie1931);
             let [x0, y0, z0] = orig.values();
             let [x1, y1, z1] = xyz_back.values();
 

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -17,8 +17,8 @@
 //! use colorimetry::cam::CamTransforms;
 //! use colorimetry::observer::Observer;
 //!
-//! let sample = XYZ::new([60.7, 49.6, 10.3], Observer::Std1931);
-//! let white  = XYZ::new([96.46, 100.0, 108.62], Observer::Std1931);
+//! let sample = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
+//! let white  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
 //! let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
 //!
 //! let cam = CieCam16::from_xyz(sample, white, vc).unwrap();
@@ -120,8 +120,8 @@ impl CieCam16 {
     /// ```rust
     /// use colorimetry::prelude::*;
     /// // Original CAM16 instance:
-    /// let sample_xyz = XYZ::new([60.7, 49.6, 10.3], Observer::Std1931);
-    /// let white_xyz  = XYZ::new([96.46, 100.0, 108.62], Observer::Std1931);
+    /// let sample_xyz = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
+    /// let white_xyz  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
     /// let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
     /// let cam = CieCam16::from_xyz(sample_xyz, white_xyz, vc).unwrap();
     ///
@@ -129,7 +129,7 @@ impl CieCam16 {
     /// let back_to_xyz = cam.xyz(None, None).unwrap();
     ///
     /// // Inverse with a new white point:
-    /// let new_white = XYZ::new([95.0, 100.0, 108.0], Observer::Std1931);
+    /// let new_white = XYZ::new([95.0, 100.0, 108.0], Observer::Cie1931);
     /// let adapted_xyz = cam.xyz(Some(new_white), None).unwrap();
     /// ```
     pub fn xyz(
@@ -180,8 +180,8 @@ mod cam16_test {
     #[test]
     fn test_worked_example() {
         // see section 7 CIE 248:2022
-        let xyz = XYZ::new([60.70, 49.60, 10.29], Observer::Std1931);
-        let xyzn = XYZ::new([96.46, 100.0, 108.62], Observer::Std1931);
+        let xyz = XYZ::new([60.70, 49.60, 10.29], Observer::Cie1931);
+        let xyzn = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
         let vc = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
         let cam = CieCam16::from_xyz(xyz, xyzn, vc).unwrap();
         let &[j, c, h] = cam.jch_vec().as_ref();
@@ -223,7 +223,7 @@ mod cam16_round_trip_tests {
 
         for &xyz_arr in samples {
             // forward transform (XYZ -> JCh)
-            let xyz = XYZ::new(xyz_arr, Observer::Std1931);
+            let xyz = XYZ::new(xyz_arr, Observer::Cie1931);
             let xyz_d65 = CIE1931.xyz_d65();
             let cam = CieCam16::from_xyz(xyz, xyz_d65, ViewConditions::default()).unwrap();
             let jch = cam.jch();
@@ -233,7 +233,7 @@ mod cam16_round_trip_tests {
             let xyz_back = cam_back.xyz(None, None).unwrap();
 
             // compare original vs. round-tripped XYZ
-            let orig = XYZ::new(xyz_arr, Observer::Std1931);
+            let orig = XYZ::new(xyz_arr, Observer::Cie1931);
             let [x0, y0, z0] = orig.values();
             let [x1, y1, z1] = xyz_back.values();
 

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -259,7 +259,7 @@ impl Illuminant {
     #[cfg(feature = "cct")]
     pub fn cct(&self) -> Result<cct::CCT, Error> {
         // CIE requires using the CIE1931 observer for calculating the CCT.
-        let xyz = self.xyz(Some(Observer::Std1931));
+        let xyz = self.xyz(Some(Observer::Cie1931));
         cct::CCT::from_xyz(xyz)
     }
 }

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -38,7 +38,7 @@ use nalgebra::{ArrayStorage, SMatrix, SVector};
 
 use crate::{
     error::Error,
-    observer::{Observer, ObserverData},
+    observer::Observer,
     spectrum::{wavelength, wavelengths, Spectrum, NS, SPECTRUM_WAVELENGTH_RANGE},
     traits::Light,
     xyz::XYZ,
@@ -183,8 +183,8 @@ impl Illuminant {
 
     /// Sets the illuminance of the illuminant spectrum, which is expressed lumen per square meter,
     /// also referred to as lux.
-    pub fn set_illuminance(mut self, obs: &ObserverData, illuminance: f64) -> Self {
-        let y = obs.y_from_spectrum(self.as_ref());
+    pub fn set_illuminance(mut self, obs: Observer, illuminance: f64) -> Self {
+        let y = obs.data().y_from_spectrum(self.as_ref());
         let l = illuminance / y;
         self.0 .0.iter_mut().for_each(|v| *v *= l);
         self
@@ -192,8 +192,8 @@ impl Illuminant {
 
     /// Calculates the illuminance of the illuminant spectrum, which is expressed in lumen per square meter,
     /// also referred to as lux.
-    pub fn illuminance(&self, obs: &ObserverData) -> f64 {
-        obs.y_from_spectrum(self.as_ref())
+    pub fn illuminance(&self, obs: Observer) -> f64 {
+        obs.data().y_from_spectrum(self.as_ref())
     }
 
     /// Calculates the Color Rendering Index values for illuminant spectrum.

--- a/src/illuminant/cct.rs
+++ b/src/illuminant/cct.rs
@@ -185,7 +185,7 @@ impl TryFrom<XYZ> for CCT {
     type Error = Error;
 
     fn try_from(xyz: XYZ) -> Result<Self, Self::Error> {
-        if xyz.observer != Observer::Std1931 {
+        if xyz.observer != Observer::Cie1931 {
             return Err(Error::RequiresCIE1931XYZ);
         }
         let [u, v] = xyz.uv60();

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -10,7 +10,7 @@ use crate::{
     colorant::{N_TCS, TCS},
     error::Error,
     illuminant::Illuminant,
-    observer::Observer::Std1931,
+    observer::Observer::Cie1931,
     xyz::XYZ,
 };
 
@@ -91,27 +91,27 @@ impl TryFrom<&Illuminant> for CRI {
     type Error = Error;
 
     fn try_from(illuminant: &Illuminant) -> Result<Self, Self::Error> {
-        let illuminant = &illuminant.clone().set_illuminance(Std1931, 100.0);
+        let illuminant = &illuminant.clone().set_illuminance(Cie1931, 100.0);
         // Calculate Device Under Test (dut) XYZ illuminant and sample values
-        let xyz_dut = Std1931.data().xyz_from_spectrum(illuminant.as_ref());
+        let xyz_dut = Cie1931.data().xyz_from_spectrum(illuminant.as_ref());
         let xyz_dut_samples: [XYZ; N_TCS] = TCS
             .each_ref()
-            .map(|colorant| Std1931.data().xyz(illuminant, Some(colorant)));
+            .map(|colorant| Cie1931.data().xyz(illuminant, Some(colorant)));
 
         // Determine reference color temperarture value
         let cct_dut = xyz_dut.cct()?.t();
         //println!("cct dut {cct_dut}");
         let illuminant_ref = if cct_dut <= 5000.0 {
-            Illuminant::planckian(cct_dut).set_illuminance(Std1931, 100.0)
+            Illuminant::planckian(cct_dut).set_illuminance(Cie1931, 100.0)
         } else {
-            Illuminant::d_illuminant(cct_dut)?.set_illuminance(Std1931, 100.0)
+            Illuminant::d_illuminant(cct_dut)?.set_illuminance(Cie1931, 100.0)
         };
 
         // Calculate the reference illuminant values
-        let xyz_ref = Std1931.data().xyz_from_spectrum(illuminant_ref.as_ref());
+        let xyz_ref = Cie1931.data().xyz_from_spectrum(illuminant_ref.as_ref());
         let xyz_ref_samples: [XYZ; N_TCS] = TCS
             .each_ref()
-            .map(|colorant| Std1931.data().xyz(&illuminant_ref, Some(colorant)));
+            .map(|colorant| Cie1931.data().xyz(&illuminant_ref, Some(colorant)));
 
         let cdt = cd(xyz_dut.uv60());
         let cdr = cd(xyz_ref.uv60());

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -10,7 +10,7 @@ use crate::{
     colorant::{N_TCS, TCS},
     error::Error,
     illuminant::Illuminant,
-    observer::CIE1931,
+    observer::Observer::Std1931,
     xyz::XYZ,
 };
 
@@ -91,27 +91,27 @@ impl TryFrom<&Illuminant> for CRI {
     type Error = Error;
 
     fn try_from(illuminant: &Illuminant) -> Result<Self, Self::Error> {
-        let illuminant = &illuminant.clone().set_illuminance(&CIE1931, 100.0);
+        let illuminant = &illuminant.clone().set_illuminance(Std1931, 100.0);
         // Calculate Device Under Test (dut) XYZ illuminant and sample values
-        let xyz_dut = CIE1931.xyz_from_spectrum(illuminant.as_ref());
+        let xyz_dut = Std1931.data().xyz_from_spectrum(illuminant.as_ref());
         let xyz_dut_samples: [XYZ; N_TCS] = TCS
             .each_ref()
-            .map(|colorant| CIE1931.xyz(illuminant, Some(colorant)));
+            .map(|colorant| Std1931.data().xyz(illuminant, Some(colorant)));
 
         // Determine reference color temperarture value
         let cct_dut = xyz_dut.cct()?.t();
         //println!("cct dut {cct_dut}");
         let illuminant_ref = if cct_dut <= 5000.0 {
-            Illuminant::planckian(cct_dut).set_illuminance(&CIE1931, 100.0)
+            Illuminant::planckian(cct_dut).set_illuminance(Std1931, 100.0)
         } else {
-            Illuminant::d_illuminant(cct_dut)?.set_illuminance(&CIE1931, 100.0)
+            Illuminant::d_illuminant(cct_dut)?.set_illuminance(Std1931, 100.0)
         };
 
         // Calculate the reference illuminant values
-        let xyz_ref = CIE1931.xyz_from_spectrum(illuminant_ref.as_ref());
+        let xyz_ref = Std1931.data().xyz_from_spectrum(illuminant_ref.as_ref());
         let xyz_ref_samples: [XYZ; N_TCS] = TCS
             .each_ref()
-            .map(|colorant| CIE1931.xyz(&illuminant_ref, Some(colorant)));
+            .map(|colorant| Std1931.data().xyz(&illuminant_ref, Some(colorant)));
 
         let cdt = cd(xyz_dut.uv60());
         let cdr = cd(xyz_ref.uv60());

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -32,7 +32,7 @@
 //! use colorimetry::prelude::*;
 //!
 //! // Convert XYZ to Lab
-//! let xyz = XYZ::new([36.0, 70.0, 12.0], Observer::Std1931);
+//! let xyz = XYZ::new([36.0, 70.0, 12.0], Observer::Cie1931);
 //! let white = CIE1931.xyz_d65(); // Reference white point (D65 illuminant)
 //! let lab1 = CieLab::from_xyz(xyz, white).unwrap();
 //!
@@ -118,8 +118,8 @@ impl CieLab {
     /// ```
     /// use colorimetry::prelude::*;
     ///
-    /// let xyz1 = XYZ::new([36.0, 70.0, 12.0], Observer::Std1931);
-    /// let xyz2 = XYZ::new([35.0, 71.0, 11.0], Observer::Std1931);
+    /// let xyz1 = XYZ::new([36.0, 70.0, 12.0], Observer::Cie1931);
+    /// let xyz2 = XYZ::new([35.0, 71.0, 11.0], Observer::Cie1931);
     /// let xyzn = CIE1931.xyz_d65(); // Reference white point (D65 illuminant)
     /// let lab1 = CieLab::from_xyz(xyz1, xyzn).unwrap();
     /// let lab2 = CieLab::from_xyz(xyz2, xyzn).unwrap();

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -72,7 +72,7 @@ use strum_macros::EnumIter;
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Debug, EnumIter)]
 pub enum Observer {
     #[default]
-    Std1931,
+    Cie1931,
 }
 
 #[cfg(feature = "supplemental-observers")]
@@ -80,10 +80,10 @@ pub enum Observer {
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Debug, EnumIter)]
 pub enum Observer {
     #[default]
-    Std1931,
-    Std1964,
-    Std2015,
-    Std2015_10,
+    Cie1931,
+    Cie1964,
+    Cie2015,
+    Cie2015_10,
 }
 
 impl Observer {
@@ -92,13 +92,13 @@ impl Observer {
     */
     pub fn data(&self) -> &'static ObserverData {
         match self {
-            Observer::Std1931 => &observers::CIE1931,
+            Observer::Cie1931 => &observers::CIE1931,
             #[cfg(feature = "supplemental-observers")]
-            Observer::Std1964 => &observers::CIE1964,
+            Observer::Cie1964 => &observers::CIE1964,
             #[cfg(feature = "supplemental-observers")]
-            Observer::Std2015 => &observers::CIE2015,
+            Observer::Cie2015 => &observers::CIE2015,
             #[cfg(feature = "supplemental-observers")]
-            Observer::Std2015_10 => &observers::CIE2015_10,
+            Observer::Cie2015_10 => &observers::CIE2015_10,
         }
     }
 }
@@ -571,7 +571,7 @@ mod obs_test {
         let d65xyz = CIE1931.xyz_d65().xyz;
         approx::assert_ulps_eq!(
             xyz,
-            crate::xyz::XYZ::from_vecs(d65xyz, crate::observer::Observer::Std1931)
+            crate::xyz::XYZ::from_vecs(d65xyz, crate::observer::Observer::Cie1931)
         );
     }
 

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 pub static CIE1931: ObserverData = ObserverData::new(
-    Observer::Std1931,
+    Observer::Cie1931,
     "CIE 1931 2°",
     683.0,
     380..=699,
@@ -417,7 +417,7 @@ pub static CIE1931: ObserverData = ObserverData::new(
 
 #[cfg(feature = "supplemental-observers")]
 pub static CIE1964: ObserverData = ObserverData::new(
-    Observer::Std1964,
+    Observer::Cie1964,
     "CIE 1964 10°",
     683.0,
     380..=701,
@@ -828,7 +828,7 @@ pub static CIE1964: ObserverData = ObserverData::new(
 
 #[cfg(feature = "supplemental-observers")]
 pub static CIE2015: ObserverData = ObserverData::new(
-    Observer::Std2015,
+    Observer::Cie2015,
     "CIE 2015 2°",
     683.0,
     390..=703,
@@ -1262,7 +1262,7 @@ pub static CIE2015: ObserverData = ObserverData::new(
 /// relevant for applications in display technology, lighting design, and colorimetry where larger visual fields
 /// are encountered.
 pub static CIE2015_10: ObserverData = ObserverData::new(
-    Observer::Std2015_10,
+    Observer::Cie2015_10,
     "CIE 2015 10°",
     683.0,
     390..=699,
@@ -1679,25 +1679,25 @@ mod tests {
 
     #[test]
     fn cie1931() {
-        test_observer_spectral_locus_wavelength_range(Observer::Std1931);
+        test_observer_spectral_locus_wavelength_range(Observer::Cie1931);
     }
 
     #[cfg(feature = "supplemental-observers")]
     #[test]
     fn cie1964() {
-        test_observer_spectral_locus_wavelength_range(Observer::Std1964);
+        test_observer_spectral_locus_wavelength_range(Observer::Cie1964);
     }
 
     #[cfg(feature = "supplemental-observers")]
     #[test]
     fn cie2015() {
-        test_observer_spectral_locus_wavelength_range(Observer::Std2015);
+        test_observer_spectral_locus_wavelength_range(Observer::Cie2015);
     }
 
     #[cfg(feature = "supplemental-observers")]
     #[test]
     fn cie2015_10() {
-        test_observer_spectral_locus_wavelength_range(Observer::Std2015_10);
+        test_observer_spectral_locus_wavelength_range(Observer::Cie2015_10);
     }
 
     /// Asserts that the `spectral_locus_range` range is correctly set for the observer.

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -1674,8 +1674,8 @@ pub static CIE2015_10: ObserverData = ObserverData::new(
 #[cfg(test)]
 mod tests {
     use crate::math::LineAB;
-    use crate::spectrum::SPECTRUM_WAVELENGTH_RANGE;
     use crate::observer::Observer;
+    use crate::spectrum::SPECTRUM_WAVELENGTH_RANGE;
 
     #[test]
     fn cie1931() {

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -1675,45 +1675,44 @@ pub static CIE2015_10: ObserverData = ObserverData::new(
 mod tests {
     use crate::math::LineAB;
     use crate::spectrum::SPECTRUM_WAVELENGTH_RANGE;
-
-    use super::*;
+    use crate::observer::Observer;
 
     #[test]
     fn cie1931() {
-        test_observer_spectral_locus_wavelength_range(&CIE1931);
+        test_observer_spectral_locus_wavelength_range(Observer::Std1931);
     }
 
     #[cfg(feature = "supplemental-observers")]
     #[test]
     fn cie1964() {
-        test_observer_spectral_locus_wavelength_range(&CIE1964);
+        test_observer_spectral_locus_wavelength_range(Observer::Std1964);
     }
 
     #[cfg(feature = "supplemental-observers")]
     #[test]
     fn cie2015() {
-        test_observer_spectral_locus_wavelength_range(&CIE2015);
+        test_observer_spectral_locus_wavelength_range(Observer::Std2015);
     }
 
     #[cfg(feature = "supplemental-observers")]
     #[test]
     fn cie2015_10() {
-        test_observer_spectral_locus_wavelength_range(&CIE2015_10);
+        test_observer_spectral_locus_wavelength_range(Observer::Std2015_10);
     }
 
     /// Asserts that the `spectral_locus_range` range is correctly set for the observer.
-    fn test_observer_spectral_locus_wavelength_range(observer: &ObserverData) {
+    fn test_observer_spectral_locus_wavelength_range(observer: Observer) {
         let min = spectral_locus_index_min(observer) + SPECTRUM_WAVELENGTH_RANGE.start();
         let max = spectral_locus_index_max(observer) + SPECTRUM_WAVELENGTH_RANGE.start();
         assert!(min >= *SPECTRUM_WAVELENGTH_RANGE.start());
         assert!(max <= *SPECTRUM_WAVELENGTH_RANGE.end());
-        assert_eq!(min..=max, observer.spectral_locus_wavelength_range());
+        assert_eq!(min..=max, observer.data().spectral_locus_wavelength_range());
     }
 
     /// The index value of the blue spectral locus edge.
     ///
     /// Any further spectral locus points will hover around this edge, and will not have a unique wavelength.
-    fn spectral_locus_index_min(observer: &ObserverData) -> usize {
+    fn spectral_locus_index_min(observer: Observer) -> usize {
         const START: usize = 100;
         let spectral_locus_pos_start = spectral_locus_by_index(observer, START).unwrap();
         let mut lp = LineAB::new(spectral_locus_pos_start, [0.33333, 0.33333]).unwrap();
@@ -1739,7 +1738,7 @@ mod tests {
     ///
     /// Any further spectral locus points will hover around this edge.
     #[cfg(test)]
-    pub(crate) fn spectral_locus_index_max(observer: &ObserverData) -> usize {
+    pub(crate) fn spectral_locus_index_max(observer: Observer) -> usize {
         const START: usize = 300;
         let spectral_locus_pos_start = spectral_locus_by_index(observer, START).unwrap();
         let mut lp = LineAB::new(spectral_locus_pos_start, [0.33333, 0.33333]).unwrap();
@@ -1763,8 +1762,9 @@ mod tests {
 
     /// Unrestricted, direct, access to the spectal locus data, in the form of
     /// chromaticity coordinates.
-    fn spectral_locus_by_index(observer: &ObserverData, i: usize) -> Option<[f64; 2]> {
-        let &[x, y, z] = observer.data.get((.., i))?.as_ref();
+    fn spectral_locus_by_index(observer: Observer, i: usize) -> Option<[f64; 2]> {
+        let obsdata = observer.data();
+        let &[x, y, z] = obsdata.data.get((.., i))?.as_ref();
         let s = x + y + z;
         if s != 0.0 {
             Some([x / s, y / s])

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -23,7 +23,7 @@
 //!   - `Rgb::from_u8(r, g, b, …)` / `Rgb::from_u16(r, g, b, …)` — byte- or word-based input  
 //! - **Color Space & Observer**  
 //!   Optionally supply a standard observer (e.g. CIE1931 or CIE2015) and an RGB color
-//!   space (e.g. sRGB, AdobeRGB). Defaults are Std1931 + sRGB.
+//!   space (e.g. sRGB, AdobeRGB). Defaults are Cie1931 + sRGB.
 //!
 //! ## Conversions
 //!
@@ -62,7 +62,7 @@ pub use widergb::WideRgb;
 use crate::{
     colorant::Colorant,
     error::Error,
-    observer::Observer::{self, Std1931},
+    observer::Observer::{self, Cie1931},
     spectrum::Spectrum,
     stimulus::Stimulus,
     traits::{Filter, Light},
@@ -122,7 +122,7 @@ impl Rgb {
     /// - `r`: Red component, in the range from 0.0 to 1.0
     /// - `g`: Green component, in the range from 0.0 to 1.0
     /// - `b`: Blue component, in the range from 0.0 to 1.0
-    /// - `observer`: Optional observer, defaults to `Observer::Std1931`
+    /// - `observer`: Optional observer, defaults to `Observer::Cie1931`
     /// - `space`: Optional RGB color space, defaults to `RgbSpace::SRGB`
     /// # Returns
     /// A new `Rgb` instance with the specified RGB values and color space.
@@ -152,7 +152,7 @@ impl Rgb {
     /// Construct a RGB instance from red, green, and blue u8 values in the range from 0 to 255.
     ///
     /// When using online RGB data, when observer and color space or color profile are not explicititely specfied,
-    /// `Observer::Std1931`, and `RgbSpace::SRGB` are implied, and those are the defaults here too.
+    /// `Observer::Cie1931`, and `RgbSpace::SRGB` are implied, and those are the defaults here too.
     pub fn from_u8(
         r_u8: u8,
         g_u8: u8,
@@ -171,7 +171,7 @@ impl Rgb {
     /// Construct a RGB instance from red, green, and blue u16 values in the range from 0 to 1.
     ///
     /// When using online RGB data, when observer and color space or color profile are not explicititely specfied,
-    /// `Observer::Std1931`, and `RgbSpace::SRGB` are implied, and those are the defaults here too.
+    /// `Observer::Cie1931`, and `RgbSpace::SRGB` are implied, and those are the defaults here too.
     pub fn from_u16(
         r_u16: u16,
         g_u16: u16,
@@ -372,16 +372,16 @@ pub fn gaussian_filtered_primaries(
     [
         Stimulus(
             Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white)
-                .set_luminance(Std1931, 100.0)
+                .set_luminance(Cie1931, 100.0)
                 .0
                 * f
                 + Stimulus(&*Colorant::gaussian(rc, rw).spectrum() * white)
-                    .set_luminance(Std1931, 100.0)
+                    .set_luminance(Cie1931, 100.0)
                     .0
                     * (1.0 - f),
         ),
-        Stimulus(&*Colorant::gaussian(gc, gw).spectrum() * white).set_luminance(Std1931, 100.0),
-        Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white).set_luminance(Std1931, 100.0),
+        Stimulus(&*Colorant::gaussian(gc, gw).spectrum() * white).set_luminance(Cie1931, 100.0),
+        Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white).set_luminance(Cie1931, 100.0),
     ]
 }
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -62,8 +62,7 @@ pub use widergb::WideRgb;
 use crate::{
     colorant::Colorant,
     error::Error,
-    observer::Observer,
-    observer::CIE1931,
+    observer::Observer::{self, Std1931},
     spectrum::Spectrum,
     stimulus::Stimulus,
     traits::{Filter, Light},
@@ -373,16 +372,16 @@ pub fn gaussian_filtered_primaries(
     [
         Stimulus(
             Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white)
-                .set_luminance(&CIE1931, 100.0)
+                .set_luminance(Std1931, 100.0)
                 .0
                 * f
                 + Stimulus(&*Colorant::gaussian(rc, rw).spectrum() * white)
-                    .set_luminance(&CIE1931, 100.0)
+                    .set_luminance(Std1931, 100.0)
                     .0
                     * (1.0 - f),
         ),
-        Stimulus(&*Colorant::gaussian(gc, gw).spectrum() * white).set_luminance(&CIE1931, 100.0),
-        Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white).set_luminance(&CIE1931, 100.0),
+        Stimulus(&*Colorant::gaussian(gc, gw).spectrum() * white).set_luminance(Std1931, 100.0),
+        Stimulus(&*Colorant::gaussian(bc, bw).spectrum() * white).set_luminance(Std1931, 100.0),
     ]
 }
 

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 use crate::xyz::Chromaticity;
 use crate::{
-    colorant::Colorant, illuminant::CieIlluminant, illuminant::D65, observer::CIE1931,
+    colorant::Colorant, illuminant::CieIlluminant, illuminant::D65, observer::Observer::Std1931,
     rgb::gamma::GammaCurve, rgb::gaussian_filtered_primaries, stimulus::Stimulus,
 };
 use strum_macros::EnumIter;
@@ -149,7 +149,7 @@ impl RgbSpaceData {
             .white
             .illuminant()
             .clone()
-            .set_illuminance(&CIE1931, 100.0)
+            .set_illuminance(Std1931, 100.0)
             .0;
         // RGB primaries defined with reference to CIE1931, and 100 cd/m2.
         let sa = self.primaries.each_ref().map(|v| &v.0 / &white);

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 use crate::xyz::Chromaticity;
 use crate::{
-    colorant::Colorant, illuminant::CieIlluminant, illuminant::D65, observer::Observer::Std1931,
+    colorant::Colorant, illuminant::CieIlluminant, illuminant::D65, observer::Observer::Cie1931,
     rgb::gamma::GammaCurve, rgb::gaussian_filtered_primaries, stimulus::Stimulus,
 };
 use strum_macros::EnumIter;
@@ -149,7 +149,7 @@ impl RgbSpaceData {
             .white
             .illuminant()
             .clone()
-            .set_illuminance(Std1931, 100.0)
+            .set_illuminance(Cie1931, 100.0)
             .0;
         // RGB primaries defined with reference to CIE1931, and 100 cd/m2.
         let sa = self.primaries.each_ref().map(|v| &v.0 / &white);

--- a/src/rgb/widergb.rs
+++ b/src/rgb/widergb.rs
@@ -71,7 +71,7 @@ impl WideRgb {
     /// - `r`: Red component, any f64 value
     /// - `g`: Green component, any f64 value
     /// - `b`: Blue component, any f64 value
-    /// - `observer`: Optional observer, defaults to `Observer::Std1931`
+    /// - `observer`: Optional observer, defaults to `Observer::Cie1931`
     /// - `space`: Optional RGB color space, defaults to `RgbSpace::SRGB`
     /// # Returns
     /// A new `WideRgb` instance with the specified RGB values and color space.

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -494,10 +494,10 @@ fn sprague(h: f64, v: &[f64]) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::observer::Observer::Cie1931;
     use crate::{illuminant::D65, prelude::*};
     use approx::assert_ulps_eq;
     use std::f64::consts::PI;
-    use crate::observer::Observer::Cie1931;
 
     #[test]
     fn test_spectrum_from_rgb() {

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -497,6 +497,7 @@ mod tests {
     use crate::{illuminant::D65, prelude::*};
     use approx::assert_ulps_eq;
     use std::f64::consts::PI;
+    use crate::observer::Observer::Std1931;
 
     #[test]
     fn test_spectrum_from_rgb() {
@@ -530,7 +531,7 @@ mod tests {
         let xyz0 = CIE1931.xyz_from_spectrum(D65.as_ref());
         let [x0, y0] = xyz0.chromaticity().to_array();
 
-        let d65 = D65.clone().set_illuminance(&CIE1931, 100.0);
+        let d65 = D65.clone().set_illuminance(Std1931, 100.0);
         let xyz = CIE1931.xyz_from_spectrum(d65.as_ref());
         let [x, y] = xyz.chromaticity().to_array();
 
@@ -588,7 +589,7 @@ mod tests {
         let chromaticity = CIE1931
             .xyz_from_spectrum(
                 Illuminant::equal_energy()
-                    .set_illuminance(&CIE1931, 100.0)
+                    .set_illuminance(Std1931, 100.0)
                     .as_ref(),
             )
             .chromaticity();
@@ -599,7 +600,7 @@ mod tests {
     #[test]
     fn d65() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(Illuminant::d65().set_illuminance(&CIE1931, 100.0).as_ref())
+            .xyz_from_spectrum(Illuminant::d65().set_illuminance(Std1931, 100.0).as_ref())
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.312_72, epsilon = 5E-5);
@@ -617,7 +618,7 @@ mod tests {
     #[test]
     fn d50() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(Illuminant::d50().set_illuminance(&CIE1931, 100.0).as_ref())
+            .xyz_from_spectrum(Illuminant::d50().set_illuminance(Std1931, 100.0).as_ref())
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.345_67, epsilon = 5E-5);

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -497,7 +497,7 @@ mod tests {
     use crate::{illuminant::D65, prelude::*};
     use approx::assert_ulps_eq;
     use std::f64::consts::PI;
-    use crate::observer::Observer::Std1931;
+    use crate::observer::Observer::Cie1931;
 
     #[test]
     fn test_spectrum_from_rgb() {
@@ -531,7 +531,7 @@ mod tests {
         let xyz0 = CIE1931.xyz_from_spectrum(D65.as_ref());
         let [x0, y0] = xyz0.chromaticity().to_array();
 
-        let d65 = D65.clone().set_illuminance(Std1931, 100.0);
+        let d65 = D65.clone().set_illuminance(Cie1931, 100.0);
         let xyz = CIE1931.xyz_from_spectrum(d65.as_ref());
         let [x, y] = xyz.chromaticity().to_array();
 
@@ -589,7 +589,7 @@ mod tests {
         let chromaticity = CIE1931
             .xyz_from_spectrum(
                 Illuminant::equal_energy()
-                    .set_illuminance(Std1931, 100.0)
+                    .set_illuminance(Cie1931, 100.0)
                     .as_ref(),
             )
             .chromaticity();
@@ -600,7 +600,7 @@ mod tests {
     #[test]
     fn d65() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(Illuminant::d65().set_illuminance(Std1931, 100.0).as_ref())
+            .xyz_from_spectrum(Illuminant::d65().set_illuminance(Cie1931, 100.0).as_ref())
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.312_72, epsilon = 5E-5);
@@ -618,7 +618,7 @@ mod tests {
     #[test]
     fn d50() {
         let chromaticity = CIE1931
-            .xyz_from_spectrum(Illuminant::d50().set_illuminance(Std1931, 100.0).as_ref())
+            .xyz_from_spectrum(Illuminant::d50().set_illuminance(Cie1931, 100.0).as_ref())
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
         assert_ulps_eq!(chromaticity.x(), 0.345_67, epsilon = 5E-5);

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -39,7 +39,7 @@ impl Stimulus {
             r_u8,
             g_u8,
             b_u8,
-            Some(crate::observer::Observer::Std1931),
+            Some(crate::observer::Observer::Cie1931),
             Some(crate::rgb::RgbSpace::SRGB),
         );
         rgb.into()

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -4,7 +4,7 @@ use std::{
     ops::{Deref, Mul},
 };
 
-use crate::{observer::ObserverData, rgb::Rgb, spectrum::Spectrum, traits::Light};
+use crate::{observer::Observer, rgb::Rgb, spectrum::Spectrum, traits::Light};
 
 #[derive(Clone)]
 pub struct Stimulus(pub(crate) Spectrum);
@@ -24,8 +24,8 @@ impl Stimulus {
     }
 
     /// Sets the luminance of the stimulus based on the observer data and a luminance value.
-    pub fn set_luminance(mut self, obs: &ObserverData, luminance: f64) -> Self {
-        let y = obs.y_from_spectrum(self.as_ref());
+    pub fn set_luminance(mut self, obs: Observer, luminance: f64) -> Self {
+        let y = obs.data().y_from_spectrum(self.as_ref());
         let l = luminance / y;
         self.0 .0.iter_mut().for_each(|v| *v *= l);
         self

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -83,7 +83,7 @@ impl XYZ {
     /// # Arguments
     /// - `chromaticity` – A `Chromaticity` struct containing the x and y coordinates.  
     /// - `l` – Optional luminous value (Y). Defaults to `100.0` if `None`, and is used to scale X and Z.  
-    /// - `observer` – Optional color-matching standard observer. Defaults to `Observer::Std1931` if `None`.
+    /// - `observer` – Optional color-matching standard observer. Defaults to `Observer::Cie1931` if `None`.
     ///
     /// # Errors
     /// - Returns `CmtError::InvalidChromaticityValues` if `x + y > 1.0 + ε`, since that cannot represent a valid chromaticity.
@@ -137,7 +137,7 @@ impl XYZ {
     /// ```
     /// use colorimetry::{xyz::XYZ, observer::Observer};
     ///
-    /// let xyz = XYZ::new([95.1, 95.0, 27.0], Observer::Std1931);
+    /// let xyz = XYZ::new([95.1, 95.0, 27.0], Observer::Cie1931);
     /// assert_eq!(xyz.x(), 95.1);
     /// ```
     pub fn x(&self) -> f64 {
@@ -153,7 +153,7 @@ impl XYZ {
     /// ```
     /// use colorimetry::{xyz::XYZ, observer::Observer};
     ///
-    /// let xyz = XYZ::new([95.1, 95.0, 27.0], Observer::Std1931);
+    /// let xyz = XYZ::new([95.1, 95.0, 27.0], Observer::Cie1931);
     /// assert_eq!(xyz.y(), 95.0);
     /// ```
     pub fn y(&self) -> f64 {
@@ -164,7 +164,7 @@ impl XYZ {
     /// ```
     /// use colorimetry::{xyz::XYZ, observer::Observer};
     ///
-    /// let xyz = XYZ::new([95.1, 95.0, 27.0], Observer::Std1931);
+    /// let xyz = XYZ::new([95.1, 95.0, 27.0], Observer::Cie1931);
     /// assert_eq!(xyz.z(), 27.0);
     /// ```
     pub fn z(&self) -> f64 {
@@ -195,10 +195,10 @@ impl XYZ {
     /// const D65A: [f64;3] = [95.04, 100.0, 108.86];
     ///
     /// let d65_xyz = CIE1931.xyz(&CieIlluminant::D65, None).set_illuminance(100.0);
-    /// assert_ulps_eq!(d65_xyz, XYZ::new(D65A, Observer::Std1931), epsilon = 1E-2);
+    /// assert_ulps_eq!(d65_xyz, XYZ::new(D65A, Observer::Cie1931), epsilon = 1E-2);
     ///
     /// let d65_xyz_sample = CIE1931.xyz(&CieIlluminant::D65, Some(&Colorant::white()));
-    /// assert_ulps_eq!(d65_xyz_sample, XYZ::new(D65A, Observer::Std1931), epsilon = 1E-2);
+    /// assert_ulps_eq!(d65_xyz_sample, XYZ::new(D65A, Observer::Cie1931), epsilon = 1E-2);
     /// ```
     pub fn set_illuminance(mut self, illuminance: f64) -> Self {
         if self.xyz.y > f64::EPSILON && illuminance > f64::EPSILON {
@@ -400,7 +400,7 @@ mod xyz_test {
 
     #[test]
     fn test_rgb_roundtrip() {
-        let rgb_blue = WideRgb::new(0.0, 0.0, 1.0, Some(Observer::Std1931), Some(RgbSpace::SRGB));
+        let rgb_blue = WideRgb::new(0.0, 0.0, 1.0, Some(Observer::Cie1931), Some(RgbSpace::SRGB));
         let xyz_blue = rgb_blue.xyz();
         let xy_blue = xyz_blue.chromaticity().to_array();
         assert_ulps_eq!(xy_blue.as_ref(), [0.15, 0.06].as_ref(), epsilon = 1E-5);
@@ -412,21 +412,21 @@ mod xyz_test {
     fn ulps_xyz_test() {
         use approx::assert_ulps_eq;
         use nalgebra::Vector3;
-        let xyz0 = XYZ::from_vecs(Vector3::zeros(), Observer::Std1931);
+        let xyz0 = XYZ::from_vecs(Vector3::zeros(), Observer::Cie1931);
 
-        let xyz1 = XYZ::from_vecs(Vector3::new(0.0, 0.0, f64::EPSILON), Observer::Std1931);
+        let xyz1 = XYZ::from_vecs(Vector3::new(0.0, 0.0, f64::EPSILON), Observer::Cie1931);
         assert_ulps_eq!(xyz0, xyz1, epsilon = 1E-5);
 
         let xyz2 = XYZ::from_vecs(
             Vector3::new(0.0, 0.0, 2.0 * f64::EPSILON),
-            Observer::Std1931,
+            Observer::Cie1931,
         );
         approx::assert_ulps_ne!(xyz0, xyz2);
 
         // different observer
         #[cfg(feature = "supplemental-observers")]
         {
-            let xyz3 = XYZ::from_vecs(Vector3::zeros(), Observer::Std1964);
+            let xyz3 = XYZ::from_vecs(Vector3::zeros(), Observer::Cie1964);
             approx::assert_ulps_ne!(xyz0, xyz3);
         }
     }

--- a/src/xyz/wasm.rs
+++ b/src/xyz/wasm.rs
@@ -11,9 +11,9 @@ impl XYZ {
     ///
     /// Accepts as arguments
     ///
-    /// - x and y chromaticity coordinates only , using the "Cie::Std1931" observer as default
+    /// - x and y chromaticity coordinates only , using the "Cie::Cie1931" observer as default
     /// - x and y chromaticity coordinates, and standard observer ID as 3rd argument
-    /// - X, Y, and Z tristimulus values, using the "Cie::Std1931" observer as default
+    /// - X, Y, and Z tristimulus values, using the "Cie::Cie1931" observer as default
     /// - X, Y, and Z tristimulus values, and a standard Observer ID as 4th argument
     ///
     /// When only x and y chromaticity coordinates are specified, the luminous
@@ -50,11 +50,11 @@ impl XYZ {
                 x * 100.0 / y,
                 100.0,
                 (1.0 - x - y) * 100.0 / y,
-                Observer::Std1931,
+                Observer::Cie1931,
             ),
             1 => {
                 if opt.get(0).as_f64().is_some() {
-                    (x, y, opt.get(0).as_f64().unwrap(), Observer::Std1931)
+                    (x, y, opt.get(0).as_f64().unwrap(), Observer::Cie1931)
                 } else {
                     let obs = Observer::try_from_js_value(opt.get(0))?;
                     (x * 100.0 / y, 100.0, (1.0 - x - y) * 100.0 / y, obs)


### PR DESCRIPTION
There is an inconsistent use of `ObserverData` and `Observer` in the API, which is confusing for users. Here, I have replaced all instances of `&ObserverData` in the public API with `Observer`, which is an `enum`, and use the `Observer.data()` method to access its data.

I have also renamed the `Observer` items from using the `Std` prefix to using the `Cie` prefix, which is commonly used to refer to CIE standard observers.