### PR TITLE
Remove ObserverData from Public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ or add this line to the dependencies in your Cargo.toml file:
 
 # Examples
 <details>
-<summary><i>Tristimulus Values</i></summary>
+<summary><i>Calculate Tristimulus Values for Illuminants</i></summary>
+
 This example calculates the XYZ tristimulus values of the D65 illuminant for both the CIE 1931 2º standard observer and the CIE 2015 10º observer.
 
 ```rust
@@ -48,7 +49,8 @@ This example calculates the XYZ tristimulus values of the D65 illuminant for bot
 </details>
 
 <details>
-<summary><i>Correlated Color Temperature</i></summary>
+<summary><i>Calculate Correlated Color Temperature and Tint</i></summary>
+
 The correlated color temperature (CCT) of an illuminant, typically expressed in kelvin (K),
 describes whether a light source appears warm (low CCT) or cool (high CCT). It is a key parameter
 for characterizing the visual appearance of white light .
@@ -71,7 +73,8 @@ locus, often referred to as the tint.
 </details>
 
 <details>
-<summary><i>Color Fidelity Index</i></summary>
+<summary><i>Calculate Color Fidelity Index for Illuminants</i></summary>
+
 The CIE has announced that the Color Fidelity Index (CFI) will replace the Color Rendering Index
 (CRI) as the standard metric for evaluating color rendering. Both indices aim to quantify how
 accurately a light source reproduces the colors of illuminated objects. However, the CFI offers a
@@ -97,7 +100,9 @@ Below is an example calculation of the general Color Fidelity Index for the CIE 
 </details>
 
 <details>
-<summary><i>Chromaticity Diagram's Spectral Locus</i></summary>
+
+<summary><i>Calculate Spectral Locus to Plot in Diagrams</i></summary>
+
 The spectral locus is the boundary in a chromaticity diagram that encloses all perceivable,
 physically realizable colors. Due to its shape, it is sometimes informally referred to as the
 "horseshoe."
@@ -118,7 +123,7 @@ Below, we compute the chromaticity coordinates that define the spectral locus.
 </details>
 
 <details>
-<summary><i>XYZ/RGB Transformation Matrices, for any Observer</i></summary>
+<summary><i>Calculate XYZ/RGB Transformation Matrices, for any Observer, for use in Color Profiles</i></summary>
 This is usually done with the CIE 1931 Standard Observer, but this library supports any observer—as long as both the color space and the data use the same one.  
 Instead of fixed XYZ values, it computes conversions from the spectral definitions of the primaries to be able to do so.
 Here, we compute transformation matrices for the `DisplayP3` color space using both the `Cie1931` and `Cie2015` observers.  

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This example calculates the XYZ tristimulus values of the D65 illuminant for bot
     # #[cfg(feature = "supplemental-observers")]
     # {
     // D65 Tristimulus values using the CIE2015 10º observer
+    // This requires the `supplemental-observers` feature (enabled by default)
     let xyz_d65_10 = D65
         .xyz(Some(Observer::Cie2015_10))
         .set_illuminance(100.0);

--- a/examples/cri.rs
+++ b/examples/cri.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let r9 = cri[9];
 
         // Calculate Correlated Color Temperature
-        let xyz = CIE1931.xyz(&spc, None);
+        let xyz = Cie1931.xyz(&spc, None);
         let cct: CCT = xyz.try_into()?;
         let [t, d] = cct.into();
         let tint = d * 1000.0;

--- a/examples/primaries.rs
+++ b/examples/primaries.rs
@@ -26,7 +26,7 @@ impl CostFunction for Gauss {
 
     fn cost(&self, param: &Self::Param) -> Result<Self::Output, argmin::core::Error> {
         let [l, w] = param.clone().try_into().unwrap();
-        let param_chromaticity = CIE1931
+        let param_chromaticity = Cie1931
             .xyz(&CieIlluminant::D65, Some(&Colorant::gaussian(l, w)))
             .chromaticity();
         //  println!("({l},{w}) cost: {xt:.4}, {yt:.4}");
@@ -60,7 +60,7 @@ impl CostFunction for GaussWithAnchor {
 
     fn cost(&self, param: &Self::Param) -> Result<Self::Output, argmin::core::Error> {
         let [l, w, c]: [f64; 3] = param.clone().try_into().unwrap();
-        let r = CIE1931
+        let r = Cie1931
             .xyz(&CieIlluminant::D65, Some(&Colorant::gaussian(l, w)))
             .set_illuminance(100.0);
         let t = c * self.anchor + (1.0 - c) * r;
@@ -76,7 +76,7 @@ fn gauss(space: RgbSpace, rgb_channel_i: usize) -> Result<Vec<f64>, String> {
     let d = space.white();
     let problem = Gauss::new(xyz, d);
 
-    let l = xyz.dominant_wavelength(CIE1931.xyz_d65()).unwrap();
+    let l = xyz.dominant_wavelength(Cie1931.xyz_d65()).unwrap();
     let w = 40.0;
 
     let solver = NelderMead::new(vec![vec![l, w], vec![l + 5.0, w], vec![l, w + 5.0]]);
@@ -106,7 +106,7 @@ fn gauss_with_anchor(space: RgbSpace, i: usize, j: usize) -> Result<Vec<f64>, St
     let problem = GaussWithAnchor::new(xyz, xyzb, d);
 
     // start parameters
-    let l = xyz.dominant_wavelength(CIE1931.xyz_d65()).unwrap();
+    let l = xyz.dominant_wavelength(Cie1931.xyz_d65()).unwrap();
     let w = 40.0;
     let c = 0.1;
 

--- a/examples/spectral_locus.rs
+++ b/examples/spectral_locus.rs
@@ -5,7 +5,7 @@ use strum::IntoEnumIterator;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     for observer in Observer::iter() {
-        let wavelength_range = observer.data().spectral_locus_wavelength_range();
+        let wavelength_range = observer.spectral_locus_wavelength_range();
         println!(
             "Spectral locus for {observer} goes from {} to {}",
             wavelength_range.start(),
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("nm\tx\t y");
         for wavelength in wavelength_range {
             // unwrap OK because nm is in range
-            let xyz = observer.data().xyz_at_wavelength(wavelength).unwrap();
+            let xyz = observer.xyz_at_wavelength(wavelength).unwrap();
             let chromaticity = xyz.chromaticity();
             println!(
                 "{wavelength}\t{:.4}\t{:.4}",

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -1,4 +1,5 @@
-//!  CIE color appearance models (CIECAM02 and CIECAM16).
+//! CIE color appearance models (CIECAM02 and CIECAM16).
+//! ====================================================
 //!
 //! This module provides structures and functions to convert between CIEXYZ tristimulus values
 //! and the perceptual correlates of human color vision. It includes:

--- a/src/cam/cam02.rs
+++ b/src/cam/cam02.rs
@@ -214,7 +214,7 @@ mod cam02_round_trip_tests {
     use crate::{
         cam::CieCam02,
         cam::{CamTransforms, ViewConditions},
-        observer::{Observer, CIE1931},
+        observer::{Observer, Observer::Cie1931},
         xyz::XYZ,
     };
     use approx::assert_abs_diff_eq;
@@ -242,7 +242,7 @@ mod cam02_round_trip_tests {
         for &xyz_arr in samples {
             // forward transform (XYZ -> JCh)
             let xyz = XYZ::new(xyz_arr, Observer::Cie1931);
-            let xyz_d65 = CIE1931.xyz_d65();
+            let xyz_d65 = Cie1931.xyz_d65();
             let cam = CieCam02::from_xyz(xyz, xyz_d65, ViewConditions::default()).unwrap();
             let jch = cam.jch();
 

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -227,9 +227,9 @@ mod cam16_test {
 
 #[cfg(test)]
 mod cam16_round_trip_tests {
+    use crate::observer::Observer::Cie1931;
     use crate::prelude::*;
     use approx::assert_abs_diff_eq;
-    use crate::observer::Observer::Cie1931;
 
     #[test]
     fn xyz_jch_xyz_round_trip() {
@@ -254,7 +254,7 @@ mod cam16_round_trip_tests {
         for &xyz_arr in samples {
             // forward transform (XYZ -> JCh)
             let xyz = XYZ::new(xyz_arr, Cie1931);
-            let xyz_d65 =Cie1931.xyz_d65();
+            let xyz_d65 = Cie1931.xyz_d65();
             let cam = CieCam16::from_xyz(xyz, xyz_d65, ViewConditions::default()).unwrap();
             let jch = cam.jch();
 

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -229,6 +229,7 @@ mod cam16_test {
 mod cam16_round_trip_tests {
     use crate::prelude::*;
     use approx::assert_abs_diff_eq;
+    use crate::observer::Observer::Cie1931;
 
     #[test]
     fn xyz_jch_xyz_round_trip() {
@@ -252,8 +253,8 @@ mod cam16_round_trip_tests {
 
         for &xyz_arr in samples {
             // forward transform (XYZ -> JCh)
-            let xyz = XYZ::new(xyz_arr, Observer::Cie1931);
-            let xyz_d65 = CIE1931.xyz_d65();
+            let xyz = XYZ::new(xyz_arr, Cie1931);
+            let xyz_d65 =Cie1931.xyz_d65();
             let cam = CieCam16::from_xyz(xyz, xyz_d65, ViewConditions::default()).unwrap();
             let jch = cam.jch();
 
@@ -262,7 +263,7 @@ mod cam16_round_trip_tests {
             let xyz_back = cam_back.xyz(None, None).unwrap();
 
             // compare original vs. round-tripped XYZ
-            let orig = XYZ::new(xyz_arr, Observer::Cie1931);
+            let orig = XYZ::new(xyz_arr, Cie1931);
             let [x0, y0, z0] = orig.values();
             let [x1, y1, z1] = xyz_back.values();
 

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -237,17 +237,17 @@ where
         Values are clamped to a range from 0.0 to 1.0.
         ```rust
         use colorimetry::illuminant::D65;
-        use colorimetry::observer::CIE1931;
+        use colorimetry::observer::Observer::Cie1931;
         use colorimetry::colorant::Colorant;
 
         // linear filter from 0.0 to 1.0.
         let tilt: Colorant = (|x:f64|x).into();
-        let xy = CIE1931.xyz(&D65, Some(&tilt)).chromaticity().to_array();
+        let xy = Cie1931.xyz(&D65, Some(&tilt)).chromaticity().to_array();
         approx::assert_abs_diff_eq!(xy.as_ref(), [0.4066, 0.4049].as_ref(), epsilon = 1E-4);
 
         // parabolic filter
         let parabolic: Colorant = (|x:f64|1.0 - 4.0 * (x - 0.5).powi(2)).into();
-        let xy = CIE1931.xyz(&D65, Some(&parabolic)).chromaticity().to_array();
+        let xy = Cie1931.xyz(&D65, Some(&parabolic)).chromaticity().to_array();
         approx::assert_abs_diff_eq!(xy.as_ref(), [0.3466, 0.3862].as_ref(), epsilon = 1E-4);
         ```
     */

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -1,4 +1,5 @@
-//! # Spectral Reflectance/Transmission Functions for Filters and Surface Colors
+//! Spectral Reflectance/Transmission Functions for Filters and Surface Colors
+//! ==========================================================================
 //!
 //! The **Colorant** module defines spectral **reflectance/transmission filters** (colorants or color patches),
 //! represented as `Spectrum` values in the range [0.0…1.0] over 380 nm…780 nm at 1 nm steps (401 samples).

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -193,8 +193,8 @@ impl Colorant {
     pub fn cielab(&self, illuminant_opt: Option<&dyn Light>, obs_opt: Option<Observer>) -> CieLab {
         let illuminant = illuminant_opt.unwrap_or(&crate::illuminant::D65);
         let obs = obs_opt.unwrap_or_default();
-        let xyzn = obs.data().xyz(illuminant, None).set_illuminance(100.0);
-        let xyz = obs.data().xyz(illuminant, Some(self));
+        let xyzn = obs.xyz(illuminant, None).set_illuminance(100.0);
+        let xyz = obs.xyz(illuminant, Some(self));
         // unwrap is safe here, as we know the illuminant and observer are valid
         CieLab::from_xyz(xyz, xyzn).unwrap()
     }

--- a/src/colorant/tcs.rs
+++ b/src/colorant/tcs.rs
@@ -35,9 +35,9 @@ pub static TCS: LazyLock<[Colorant; N_TCS]> = LazyLock::new(|| {
 
 #[test]
 fn tcs_test() {
-    use crate::observer::CIE1931;
+    use crate::observer::Observer::Cie1931;
     for (i, s) in TCS.iter().enumerate() {
-        let xyz = CIE1931.xyz(&crate::illuminant::CieIlluminant::D65, Some(s));
+        let xyz = Cie1931.xyz(&crate::illuminant::CieIlluminant::D65, Some(s));
         let [r, g, b]: [u8; 3] = xyz.rgb(Some(crate::rgb::RgbSpace::SRGB)).clamp().into();
         println!("{:2} ({r:3},{g:3},{b:3})", i + 1);
     }

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -123,7 +123,7 @@ impl Illuminant {
     /// # use approx::assert_ulps_eq;
     ///
     /// let p3000 = Illuminant::planckian(3000.0);
-    /// let xyz = CIE1931.xyz(&p3000, None);
+    /// let xyz = Cie1931.xyz(&p3000, None);
     /// let chromaticity = xyz.chromaticity();
     /// assert_ulps_eq!(chromaticity.x(), 0.436_935, epsilon = 1E-6);
     /// assert_ulps_eq!(chromaticity.y(), 0.404_083, epsilon = 1E-6);

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -184,7 +184,7 @@ impl Illuminant {
     /// Sets the illuminance of the illuminant spectrum, which is expressed lumen per square meter,
     /// also referred to as lux.
     pub fn set_illuminance(mut self, obs: Observer, illuminance: f64) -> Self {
-        let y = obs.data().y_from_spectrum(self.as_ref());
+        let y = obs.y_from_spectrum(self.as_ref());
         let l = illuminance / y;
         self.0 .0.iter_mut().for_each(|v| *v *= l);
         self
@@ -193,7 +193,7 @@ impl Illuminant {
     /// Calculates the illuminance of the illuminant spectrum, which is expressed in lumen per square meter,
     /// also referred to as lux.
     pub fn illuminance(&self, obs: Observer) -> f64 {
-        obs.data().y_from_spectrum(self.as_ref())
+        obs.y_from_spectrum(self.as_ref())
     }
 
     /// Calculates the Color Rendering Index values for illuminant spectrum.
@@ -253,7 +253,7 @@ impl Illuminant {
     /// none is provided.
     pub fn xyz(&self, obs_opt: Option<Observer>) -> XYZ {
         let obs = obs_opt.unwrap_or_default();
-        obs.data().xyz_from_spectrum(&self.0)
+        obs.xyz_from_spectrum(&self.0)
     }
 
     /// Calculate the correlated color temperature (CCT) of the illuminant.
@@ -327,9 +327,10 @@ impl Light for Illuminant {
 #[test]
 fn test_d_illuminant() {
     use crate::prelude::*;
+    use crate::observer::Observer::Cie1931;
     let s = Illuminant::d_illuminant(6504.0).unwrap();
-    let xyz = CIE1931.xyz_from_spectrum(s.as_ref()).set_illuminance(100.0);
-    approx::assert_ulps_eq!(xyz, CIE1931.xyz_d65(), epsilon = 2E-2);
+    let xyz = Cie1931.xyz_from_spectrum(s.as_ref()).set_illuminance(100.0);
+    approx::assert_ulps_eq!(xyz, Cie1931.xyz_d65(), epsilon = 2E-2);
 }
 
 #[test]
@@ -347,7 +348,7 @@ fn test_xyz() {
     let s = *Illuminant::d_illuminant(6504.0).unwrap().as_ref().values();
     let illuminant = Illuminant(Spectrum::from(s));
     let xyz = illuminant.xyz(None).set_illuminance(100.0);
-    approx::assert_ulps_eq!(xyz, CIE1931.xyz_d65(), epsilon = 2E-2);
+    approx::assert_ulps_eq!(xyz, Observer::Cie1931.xyz_d65(), epsilon = 2E-2);
 }
 
 const CIE_D_S_LEN: usize = 81;

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -326,8 +326,8 @@ impl Light for Illuminant {
 
 #[test]
 fn test_d_illuminant() {
-    use crate::prelude::*;
     use crate::observer::Observer::Cie1931;
+    use crate::prelude::*;
     let s = Illuminant::d_illuminant(6504.0).unwrap();
     let xyz = Cie1931.xyz_from_spectrum(s.as_ref()).set_illuminance(100.0);
     approx::assert_ulps_eq!(xyz, Cie1931.xyz_d65(), epsilon = 2E-2);

--- a/src/illuminant/cct.rs
+++ b/src/illuminant/cct.rs
@@ -42,7 +42,7 @@ use std::sync::OnceLock;
 use approx::{ulps_eq, AbsDiffEq, RelativeEq, UlpsEq};
 
 use crate::{
-    error::Error, math::distance_to_line, observer::Observer, observer::CIE1931, xyz::XYZ,
+    error::Error, math::distance_to_line, observer::Observer, observer::Observer::Cie1931, xyz::XYZ,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -258,10 +258,10 @@ impl TryFrom<CCT> for XYZ {
 /// These are the coordinates of the blackbody locus at temperature T, and it's line normal,
 /// which is the slope of the curve at that point rotated by 90º.
 fn iso_temp_line(t: f64) -> [f64; 3] {
-    let xyz = CIE1931.xyz_planckian_locus(t);
+    let xyz = Cie1931.xyz_planckian_locus(t);
     let [x, y, z] = xyz.values();
     let [u, v] = xyz.uv60();
-    let [dx, dy, dz] = CIE1931.xyz_planckian_locus_slope(t).values();
+    let [dx, dy, dz] = Cie1931.xyz_planckian_locus_slope(t).values();
     let sigma = x + 15.0 * y + 3.0 * z;
     let dsigma = dx + 15.0 * dy + 3.0 * dz;
     let den = 6.0 * y * dsigma - 6.0 * dy * sigma;
@@ -455,7 +455,7 @@ mod tests {
     #[cfg(feature = "cie-illuminants")]
     fn f1_test() {
         let xyz_f1 =
-            CIE1931.xyz_cie_table(&crate::illuminant::cie_illuminant::CieIlluminant::F1, None);
+            Cie1931.xyz_cie_table(&crate::illuminant::cie_illuminant::CieIlluminant::F1, None);
         // value from CIE Standard CIE15:2004 Table T8.1
         approx::assert_ulps_eq!(xyz_f1.cct().unwrap().t(), 6430.0, epsilon = 0.5);
     }
@@ -463,7 +463,7 @@ mod tests {
     #[test]
     #[cfg(feature = "cie-illuminants")]
     fn f3_1_test() {
-        let xyz_f3_1 = CIE1931.xyz_cie_table(
+        let xyz_f3_1 = Cie1931.xyz_cie_table(
             &crate::illuminant::cie_illuminant::CieIlluminant::F3_1,
             None,
         );

--- a/src/illuminant/cfi.rs
+++ b/src/illuminant/cfi.rs
@@ -1,5 +1,5 @@
 use crate::math::distance;
-use crate::observer::CIE1964;
+use crate::observer::Observer::Cie1964;
 use crate::{
     cam::{CamTransforms, CieCam02, TM30VC},
     colorant::{CES_DATA, N_CFI},
@@ -51,16 +51,16 @@ impl CFI {
         let cct = illuminant.cct()?;
         let ref_illuminant = Illuminant::cfi_reference(cct.t())?;
         let vc = TM30VC;
-        let xyzn_r = CIE1964.xyz(&ref_illuminant, None).set_illuminance(100.0);
-        let xyzn_t = CIE1964.xyz(illuminant, None).set_illuminance(100.0);
+        let xyzn_r = Cie1964.xyz(&ref_illuminant, None).set_illuminance(100.0);
+        let xyzn_t = Cie1964.xyz(illuminant, None).set_illuminance(100.0);
         let mut jabp_ts = [[0f64; 3]; N_CFI];
         let mut jabp_rs = [[0f64; 3]; N_CFI];
         for (i, cfi_ces) in CES_DATA.iter().enumerate() {
-            let xyz_t = CIE1964.xyz(illuminant, Some(cfi_ces));
+            let xyz_t = Cie1964.xyz(illuminant, Some(cfi_ces));
             let jabp_t = CieCam02::from_xyz(xyz_t, xyzn_t, vc)?.jab_prime();
             jabp_ts[i] = jabp_t;
 
-            let xyz_r = CIE1964.xyz(&ref_illuminant, Some(cfi_ces));
+            let xyz_r = Cie1964.xyz(&ref_illuminant, Some(cfi_ces));
             let jabp_r = CieCam02::from_xyz(xyz_r, xyzn_r, vc)?.jab_prime();
             jabp_rs[i] = jabp_r;
         }

--- a/src/illuminant/cie_illuminant.rs
+++ b/src/illuminant/cie_illuminant.rs
@@ -88,7 +88,7 @@ impl Light for CieIlluminant {
         observer: crate::observer::Observer,
         illuminance: Option<f64>,
     ) -> crate::xyz::XYZ {
-        observer.data().xyz_cie_table(self, illuminance)
+        observer.xyz_cie_table(self, illuminance)
     }
 
     fn spectrum(&self) -> Cow<'_, Spectrum> {

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -93,10 +93,10 @@ impl TryFrom<&Illuminant> for CRI {
     fn try_from(illuminant: &Illuminant) -> Result<Self, Self::Error> {
         let illuminant = &illuminant.clone().set_illuminance(Cie1931, 100.0);
         // Calculate Device Under Test (dut) XYZ illuminant and sample values
-        let xyz_dut = Cie1931.data().xyz_from_spectrum(illuminant.as_ref());
+        let xyz_dut = Cie1931.xyz_from_spectrum(illuminant.as_ref());
         let xyz_dut_samples: [XYZ; N_TCS] = TCS
             .each_ref()
-            .map(|colorant| Cie1931.data().xyz(illuminant, Some(colorant)));
+            .map(|colorant| Cie1931.xyz(illuminant, Some(colorant)));
 
         // Determine reference color temperarture value
         let cct_dut = xyz_dut.cct()?.t();
@@ -108,10 +108,10 @@ impl TryFrom<&Illuminant> for CRI {
         };
 
         // Calculate the reference illuminant values
-        let xyz_ref = Cie1931.data().xyz_from_spectrum(illuminant_ref.as_ref());
+        let xyz_ref = Cie1931.xyz_from_spectrum(illuminant_ref.as_ref());
         let xyz_ref_samples: [XYZ; N_TCS] = TCS
             .each_ref()
-            .map(|colorant| Cie1931.data().xyz(&illuminant_ref, Some(colorant)));
+            .map(|colorant| Cie1931.xyz(&illuminant_ref, Some(colorant)));
 
         let cdt = cd(xyz_dut.uv60());
         let cdr = cd(xyz_ref.uv60());

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -295,10 +295,10 @@ fn delta_e_ciede2000(lab1: Vector3<f64>, lab2: Vector3<f64>) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::observer::Observer::Cie1931;
     use crate::prelude::*;
     use approx::assert_abs_diff_eq;
     use nalgebra::vector;
-    use crate::observer::Observer::Cie1931;
 
     #[test]
     fn delta_e_ciede2000_example1() {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -298,6 +298,7 @@ mod tests {
     use crate::prelude::*;
     use approx::assert_abs_diff_eq;
     use nalgebra::vector;
+    use crate::observer::Observer::Cie1931;
 
     #[test]
     fn delta_e_ciede2000_example1() {
@@ -488,7 +489,7 @@ mod tests {
             ),
         ];
 
-        let xyz_d65 = CIE1931.xyz_d65();
+        let xyz_d65 = Cie1931.xyz_d65();
         for &(lab1_arr, lab2_arr, expected) in cases {
             let lab1 = CieLab::new(lab1_arr, xyz_d65);
             let lab2 = CieLab::new(lab2_arr, xyz_d65);

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -33,7 +33,7 @@
 //!
 //! // Convert XYZ to Lab
 //! let xyz = XYZ::new([36.0, 70.0, 12.0], Observer::Cie1931);
-//! let white = CIE1931.xyz_d65(); // Reference white point (D65 illuminant)
+//! let white = Cie1931.xyz_d65(); // Reference white point (D65 illuminant)
 //! let lab1 = CieLab::from_xyz(xyz, white).unwrap();
 //!
 //! // Direct Lab constructor
@@ -120,7 +120,7 @@ impl CieLab {
     ///
     /// let xyz1 = XYZ::new([36.0, 70.0, 12.0], Observer::Cie1931);
     /// let xyz2 = XYZ::new([35.0, 71.0, 11.0], Observer::Cie1931);
-    /// let xyzn = CIE1931.xyz_d65(); // Reference white point (D65 illuminant)
+    /// let xyzn = Cie1931.xyz_d65(); // Reference white point (D65 illuminant)
     /// let lab1 = CieLab::from_xyz(xyz1, xyzn).unwrap();
     /// let lab2 = CieLab::from_xyz(xyz2, xyzn).unwrap();
     /// let de = lab1.ciede(&lab2).unwrap();
@@ -161,7 +161,7 @@ impl CieLab {
     /// use colorimetry::prelude::*;
     ///
     /// // Sharma et al. (2005) test case 25
-    /// let xyz_d65 = CIE1931.xyz_d65();
+    /// let xyz_d65 = Cie1931.xyz_d65();
     /// let lab1 = CieLab::new([60.2574, -34.0099, 36.2677], xyz_d65);
     /// let lab2 = CieLab::new([60.4626, -34.1751, 39.4387], xyz_d65);
     /// let de = lab1.ciede2000(&lab2).unwrap();

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -102,33 +102,250 @@ impl Observer {
         }
     }
 
+    /// Returns the observer's color matching function (CMF) data as an [XYZ] tristimulus
+    /// value for the given wavelength.
+    ///
+    /// This allows access to the underlying data for the entire range of wavelengths, 380-780nm.
+    /// However, please read the documentation for the
+    /// [`spectral_locus_wavelength_range`](Self::spectral_locus_wavelength_range) method on
+    /// situations where you might not want to sample the full range.
     pub fn xyz_at_wavelength(&self, wavelength: usize) -> Result<XYZ, Error> {
-        self.data().xyz_at_wavelength(wavelength)
+        if !SPECTRUM_WAVELENGTH_RANGE.contains(&wavelength) {
+            return Err(Error::WavelengthOutOfRange);
+        };
+        let &[x, y, z] = self.data()
+            .data
+            .column(wavelength - SPECTRUM_WAVELENGTH_RANGE.start())
+            .as_ref();
+        Ok(XYZ::from_vecs(Vector3::new(x, y, z), self.data().tag))
     }
 
-    pub fn spectral_locus_wavelength_range(&self) -> RangeInclusive<usize> {
-        self.data().spectral_locus_wavelength_range()
+    /// Tristimulus values for the Standard Illuminants in this library.
+    ///
+    /// Values are not normalized by default, unless an illuminance value is provided.
+    ///
+    /// TODO: buffer values
+    pub fn xyz_cie_table(&self, std_illuminant: &CieIlluminant, illuminance: Option<f64>) -> XYZ {
+        let xyz = self.xyz_from_spectrum(std_illuminant.illuminant().as_ref());
+        if let Some(l) = illuminance {
+            xyz.set_illuminance(l)
+        } else {
+            xyz
+        }
     }
+
+    /// Returns the name of the observer.
     pub fn name(&self) -> &'static str {
-        self.data().name()
+        &self.data().name
     }
 
+    /// Calulates Tristimulus values for an object implementing the [Light] trait, and an optional [Filter],
+    /// filtering the light.
+    ///
+    /// The Light trait is implemented by [`CieIlluminant`] and [Illuminant](crate::illuminant::Illuminant).
+    ///
+    /// [`Colorant`](crate::colorant::Colorant) implments the [`Filter`] trait.
+    /// [`Rgb`](crate::rgb::Rgb), which represents a display pixel, implements both in this library.
+    /// As a light, it is the light emitted from the pixel, as a filter it is the RGB-composite
+    /// filter which is applied to the underlying standard illuminant of color space.
     pub fn xyz(&self, light: &dyn Light, filter: Option<&dyn Filter>) -> XYZ {
-        self.data().xyz(light, filter)
+        let xyzn = light.xyzn(self.data().tag, None);
+        if let Some(flt) = filter {
+            let s = *light.spectrum() * *flt.spectrum();
+            let xyz = self.xyz_from_spectrum(&s);
+            let scale = 100.0 / xyzn.xyz.y;
+            xyz * scale
+        } else {
+            xyzn
+        }
     }
 
+    /// XYZ tristimulus values for the CIE standard daylight illuminant D65 (buffered).
+    pub fn xyz_d65(&self) -> XYZ {
+        *self.data().d65.get_or_init(|| {
+            self.xyz_from_spectrum(CieIlluminant::D65.illuminant().as_ref())
+                .set_illuminance(100.0)
+        })
+    }
+
+
+    /// XYZ tristimulus values for the CIE standard daylight illuminant D50 (buffered).
+    pub fn xyz_d50(&self) -> XYZ {
+        *self.data().d50.get_or_init(|| {
+            self.xyz_from_spectrum(CieIlluminant::D50.illuminant().as_ref())
+                .set_illuminance(100.0)
+        })
+    }
+
+    /// Calculates the L*a*b* CIELAB D50 values of a Colorant, using D65 as an illuminant.
+    /// Accepts a Colorant Spectrum only.
+    /// Returns f64::NAN's otherwise.
+    pub fn lab_d50(&self, filter: &dyn Filter) -> CieLab {
+        let xyz = self.xyz(&CieIlluminant::D50, Some(filter));
+        let xyzn = self.xyz_d50();
+        CieLab::from_xyz(xyz, xyzn).unwrap()
+    }
+
+    /// Calculates the L*a*b* CIELAB D65 values of a Colorant, using D65 as an illuminant.
+    /// Accepts a Colorant Spectrum only.
+    /// Returns f64::NAN's otherwise.
+    pub fn lab_d65(&self, filter: &dyn Filter) -> CieLab {
+        let xyz = self.xyz(&CieIlluminant::D65, Some(filter));
+        let xyzn = self.xyz_d65();
+        CieLab::from_xyz(xyz, xyzn).unwrap()
+    }
+
+    /// Calculates XYZ tristimulus values for a Planckian emitter for this
+    /// observer. The `to_wavelength`` function is used, as planck functions
+    /// requires the wavelength to be in units of meters, and the
+    /// `xyz_from_illuminant_as_fn` uses functions over a domain from 0.0 to
+    /// 1.0.
+    pub fn xyz_planckian_locus(&self, cct: f64) -> XYZ {
+        let p = Planck::new(cct);
+        self.xyz_from_fn(|l| p.at_wavelength(to_wavelength(l, 0.0, 1.0)))
+    }
+
+
+    /// Calculates the RGB to XYZ matrix, for a particular color space.
     pub fn rgb2xyz(&self, rgbspace: RgbSpace) -> Matrix3<f64> {
-        self.data().rgb2xyz(rgbspace)
+        let space = rgbspace.data();
+        let mut rgb2xyz = Matrix3::from_iterator(
+            space
+                .primaries
+                .iter()
+                .flat_map(|s| self.xyz_from_spectrum(s).set_illuminance(1.0).values()),
+        );
+        let xyzw = self.xyz(&space.white, None).set_illuminance(1.0);
+        let decomp = rgb2xyz.lu();
+        // unwrap: only used with library color spaces
+        let rgbw = decomp.solve(&xyzw.xyz).unwrap();
+        for (i, mut col) in rgb2xyz.column_iter_mut().enumerate() {
+            col *= rgbw[i];
+        }
+        rgb2xyz
     }
 
+    /// Calculates the XYZ to RGB matrix, for a particular color space.
     pub fn xyz2rgb(&self, rgbspace: RgbSpace) -> Matrix3<f64> {
-        self.data().xyz2rgb(rgbspace)
+        // unwrap: only used with library color spaces
+        self.rgb2xyz(rgbspace).try_inverse().unwrap()
     }
+
+    /**
+        Calculates Tristimulus valus, in form of an [XYZ] object of a general spectrum.
+        If a reference white is given (rhs), it will copy its tristimulus value, and the spectrum
+        is interpreted as a stimulus, being a combination of an illuminant with a colorant.
+        If no reference white is given, the spectrum is interpreted as an illuminant.
+        This method produces the raw XYZ data, not normalized to 100.0
+
+    */
+    pub fn xyz_from_spectrum(&self, spectrum: &Spectrum) -> XYZ {
+        let xyz = self.data().data * spectrum.0 * self.data().lumconst;
+        XYZ::from_vecs(xyz, self.data().tag)
+    }
+
+    /// Calculates the lumimous value or Y tristimulus value for a general spectrum.
+    pub fn y_from_spectrum(&self, spectrum: &Spectrum) -> f64 {
+        (self.data().data.row(1) * spectrum.0 * self.data().lumconst)[(0, 0)]
+    }
+
+    /// Returns the wavelength range (in nanometer) for the _horse shoe_,
+    /// the boundary of the area of all physical colors in a chromiticity diagram,
+    /// for this observer.
+    ///
+    /// Spectral locus points tend to freeze, or even fold back to lower wavelength
+    /// values at the blue and red perimeter ends. This can be quite anoying, for
+    /// example when trying to calculate dominant wavelength, or when creating
+    /// plots.
+    /// See Wikipedia's [CIE 1931 Color Space](https://en.wikipedia.org/wiki/CIE_1931_color_space).
+    ///
+    /// To help with the above problem, this method returns the wavelength range
+    /// for which the spectral locus points are unique, meaning
+    /// each wavelength has a chromaticity coordinate different from the wavelength
+    /// below or above it.
+    ///
+    /// To get the tristimulus values of the spectral locus, use
+    /// [`xyz_at_wavelength`](Self::xyz_at_wavelength).
+    pub fn spectral_locus_wavelength_range(&self) -> RangeInclusive<usize> {
+        self.data().spectral_locus_range.clone()
+    }
+
+    /// Calculates the XYZ tristimulus values for a spectrum defined by a function.
+    ///
+    /// The input function `f` should accept a floating-point value in the range `[0.0, 1.0]`,
+    /// where `0.0` corresponds to a wavelength of 380 nm and `1.0` to 780 nm.
+    /// The function will be called once for each wavelength step (401 times at 1 nm intervals).
+    ///
+    /// # Arguments
+    /// * `f` - A function that takes a floating-point value in the range `[0.0, 1.0]` and returns
+    ///   the spectral value at that wavelength, in units of watts per square meter per nanometer (W/m²/nm) for
+    ///   illuminants, or Watts per square meter per steradian per nanometer (W/m²/sr/nm) for stimuli.
+    ///
+    /// # Notes
+    /// - This method is used in the library to compute the Planckian locus (the color of blackbody
+    ///   radiators), as described by Planck's law.
+    /// - For colorants, use [`xyz_from_colorant_fn`](Self::xyz_from_colorant_fn).
+    pub fn xyz_from_fn(&self, f: impl Fn(f64) -> f64) -> XYZ {
+        let xyz = self
+            .data()
+            .data
+            .column_iter()
+            .enumerate()
+            .fold(Vector3::zeros(), |acc, (i, cmf)| {
+                acc + cmf * f(i as f64 / (NS - 1) as f64)
+            });
+        XYZ {
+            xyz,
+            observer: self.data().tag,
+        }
+    }
+
+    /// Calculates XYZ tristimulus values for an analytic representation of a spectral distribution of
+    /// a filter or a color patch, using a normalized wavelength domain ranging from a value of 0.0 to 1.0,
+    /// illuminated with a standard illuminant.
+    ///
+    /// The spectral values should be defined within a range from 0.0 to 1.0, and are clamped otherwise.
+    /// The resulting XYZ value will have relative Y values in the range from 0 to 100.0.
+    ///
+    /// # Examples
+    /// A linear high pass filter, with a value of 0.0 for a wavelength of 380nm, and a value of 1.0 for 780nm,
+    /// and converting the resulting value to RGB values.
+    /// ```
+    /// use colorimetry::prelude::*;
+    /// let rgb: [u8;3] = CIE1931.xyz_from_colorant_fn(&CieIlluminant::D65, |x|x).rgb(None).clamp().into();
+    /// assert_eq!(rgb, [212, 171, 109]);
+    /// ```
+    /// Linear low pass filter, with a value of 1.0 for a wavelength of 380nm, and a value of 0.0 for 780nm,
+    /// and converting the resulting value to RGB values.
+    /// ```
+    /// use colorimetry::prelude::*;
+    /// let rgb: [u8;3] = CIE1931.xyz_from_colorant_fn(&CieIlluminant::D65, |x|1.0-x).rgb(None).clamp().into();
+    /// assert_eq!(rgb, [158, 202, 237]);
+    /// ```
+    pub fn xyz_from_colorant_fn(&self, illuminant: &CieIlluminant, f: impl Fn(f64) -> f64) -> XYZ {
+        let ill = illuminant.illuminant();
+        let xyzn = self.xyz_cie_table(illuminant, None);
+        let xyz = self
+            .data()
+            .data
+            .column_iter()
+            .zip(ill.0 .0.iter())
+            .enumerate()
+            .fold(Vector3::zeros(), |acc, (i, (cmfi, sv))| {
+                acc + cmfi * f(i as f64 / (NS - 1) as f64).clamp(0.0, 1.0) * *sv
+            });
+        let scale = 100.0 / xyzn.xyz.y;
+        XYZ {
+            xyz: xyz * self.data().lumconst * scale,
+            observer: self.data().tag,
+        }
+    }
+
 }
 
 impl fmt::Display for Observer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.data().name().fmt(f)
+        self.name().fmt(f)
     }
 }
 
@@ -152,7 +369,7 @@ impl fmt::Display for Observer {
     in from of a `Spectrum`.
 */
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
-pub struct ObserverData {
+pub(crate) struct ObserverData {
     data: SMatrix<f64, 3, NS>,
     lumconst: f64,
     tag: Observer,
@@ -189,278 +406,13 @@ impl ObserverData {
         }
     }
 
-    /// Returns the name of the observer.
-    pub fn name(&self) -> &'static str {
-        self.name
-    }
-
-    /// Calulates Tristimulus values for an object implementing the [Light] trait, and an optional [Filter],
-    /// filtering the light.
-    ///
-    /// The Light trait is implemented by [`CieIlluminant`] and [Illuminant](crate::illuminant::Illuminant).
-    ///
-    /// [`Colorant`](crate::colorant::Colorant) implments the [`Filter`] trait.
-    /// [`Rgb`](crate::rgb::Rgb), which represents a display pixel, implements both in this library.
-    /// As a light, it is the light emitted from the pixel, as a filter it is the RGB-composite
-    /// filter which is applied to the underlying standard illuminant of color space.
-    pub fn xyz(&self, light: &dyn Light, filter: Option<&dyn Filter>) -> XYZ {
-        let xyzn = light.xyzn(self.tag, None);
-        if let Some(flt) = filter {
-            let s = *light.spectrum() * *flt.spectrum();
-            let xyz = self.xyz_from_spectrum(&s);
-            let scale = 100.0 / xyzn.xyz.y;
-            xyz * scale
-        } else {
-            xyzn
-        }
-    }
-
-    /**
-        Calculates Tristimulus valus, in form of an [XYZ] object of a general spectrum.
-        If a reference white is given (rhs), it will copy its tristimulus value, and the spectrum
-        is interpreted as a stimulus, being a combination of an illuminant with a colorant.
-        If no reference white is given, the spectrum is interpreted as an illuminant.
-        This method produces the raw XYZ data, not normalized to 100.0
-
-    */
-    pub fn xyz_from_spectrum(&self, spectrum: &Spectrum) -> XYZ {
-        let xyz = self.data * spectrum.0 * self.lumconst;
-        XYZ::from_vecs(xyz, self.tag)
-    }
-
-    /// Calculates the lumimous value or Y tristimulus value for a general spectrum.
-    pub fn y_from_spectrum(&self, spectrum: &Spectrum) -> f64 {
-        (self.data.row(1) * spectrum.0 * self.lumconst)[(0, 0)]
-    }
-
-    /// Returns the observer's color matching function (CMF) data as an [XYZ] tristimulus
-    /// value for the given wavelength.
-    ///
-    /// This allows access to the underlying data for the entire range of wavelengths, 380-780nm.
-    /// However, please read the documentation for the
-    /// [`spectral_locus_wavelength_range`](Self::spectral_locus_wavelength_range) method on
-    /// situations where you might not want to sample the full range.
-    pub fn xyz_at_wavelength(&self, wavelength: usize) -> Result<XYZ, Error> {
-        if !SPECTRUM_WAVELENGTH_RANGE.contains(&wavelength) {
-            return Err(Error::WavelengthOutOfRange);
-        };
-        let &[x, y, z] = self
-            .data
-            .column(wavelength - SPECTRUM_WAVELENGTH_RANGE.start())
-            .as_ref();
-        Ok(XYZ::from_vecs(Vector3::new(x, y, z), self.tag))
-    }
-
-    /// Tristimulus values for the Standard Illuminants in this library.
-    ///
-    /// Values are not normalized by default, unless an illuminance value is provided.
-    ///
-    /// TODO: buffer values
-    pub fn xyz_cie_table(&self, std_illuminant: &CieIlluminant, illuminance: Option<f64>) -> XYZ {
-        let xyz = self.xyz_from_spectrum(std_illuminant.illuminant().as_ref());
-        if let Some(l) = illuminance {
-            xyz.set_illuminance(l)
-        } else {
-            xyz
-        }
-    }
-
-    /// XYZ tristimulus values for the CIE standard daylight illuminant D65 (buffered).
-    ///
-    /// # Examples
-    /// ```
-    /// // Test data from [CIE 15:2018](https://cie.co.at/publications/colorimetry-4th-edition) for test data
-    /// use colorimetry::{xyz::XYZ, illuminant::CieIlluminant};
-    ///
-    /// let cie1931_d65_xyz = colorimetry::observer::CIE1931.xyz_d65();
-    /// approx::assert_ulps_eq!(cie1931_d65_xyz.values().as_ref(), [95.047, 100.0, 108.883].as_ref(), epsilon = 5E-2);
-    /// ```
-    pub fn xyz_d65(&self) -> XYZ {
-        *self.d65.get_or_init(|| {
-            self.xyz_from_spectrum(CieIlluminant::D65.illuminant().as_ref())
-                .set_illuminance(100.0)
-        })
-    }
-
-    /// XYZ tristimulus values for the CIE standard daylight illuminant D50 (buffered).
-    ///
-    /// # Examples
-    /// ```ignore
-    /// // Test data from [CIE 15:2018](https://cie.co.at/publications/colorimetry-4th-edition) for test data
-    /// use colorimetry::{xyz::XYZ, illuminant::CieIlluminant};
-    ///
-    /// let cie1931_d50_xyz = colorimetry::observer::CIE1931.xyz_d50();
-    /// approx::assert_ulps_eq!(cie1931_d50_xyz.values().as_ref(), [96.421, 100.0, 82.519].as_ref(), epsilon = 5E-2);
-    ///
-    /// # #[cfg(feature = "supplemental-observers")]
-    /// # {
-    /// let cie1964_d50_xyz = colorimetry::observer::CIE1964.xyz_d50();
-    /// approx::assert_ulps_eq!(cie1964_d50_xyz.values().as_ref(), [96.720, 100.0, 81.427].as_ref(), epsilon = 5E-2);
-    /// # }
-    /// ```
-    pub fn xyz_d50(&self) -> XYZ {
-        *self.d50.get_or_init(|| {
-            self.xyz_from_spectrum(CieIlluminant::D50.illuminant().as_ref())
-                .set_illuminance(100.0)
-        })
-    }
-
-    /// Calculates XYZ tristimulus values for a Planckian emitter for this
-    /// observer. The `to_wavelength`` function is used, as planck functions
-    /// requires the wavelength to be in units of meters, and the
-    /// `xyz_from_illuminant_as_fn` uses functions over a domain from 0.0 to
-    /// 1.0.
-    pub fn xyz_planckian_locus(&self, cct: f64) -> XYZ {
-        let p = Planck::new(cct);
-        self.xyz_from_fn(|l| p.at_wavelength(to_wavelength(l, 0.0, 1.0)))
-    }
-
-    /// The slope of the Plancking locus as a (dX/dT, dY/dT, dZ/dT) contained in
-    /// a XYZ object.
-    pub fn xyz_planckian_locus_slope(&self, cct: f64) -> XYZ {
-        let p = Planck::new(cct);
-        self.xyz_from_fn(|l| p.slope_at_wavelength(to_wavelength(l, 0.0, 1.0)))
-    }
-
-    /// Calculates the L*a*b* CIELAB D65 values of a Colorant, using D65 as an illuminant.
-    /// Accepts a Colorant Spectrum only.
-    /// Returns f64::NAN's otherwise.
-    pub fn lab_d65(&self, filter: &dyn Filter) -> CieLab {
-        let xyz = self.xyz(&CieIlluminant::D65, Some(filter));
-        let xyzn = self.xyz_d65();
-        CieLab::from_xyz(xyz, xyzn).unwrap()
-    }
-
-    /// Calculates the L*a*b* CIELAB D50 values of a Colorant, using D65 as an illuminant.
-    /// Accepts a Colorant Spectrum only.
-    /// Returns f64::NAN's otherwise.
-    pub fn lab_d50(&self, filter: &dyn Filter) -> CieLab {
-        let xyz = self.xyz(&CieIlluminant::D50, Some(filter));
-        let xyzn = self.xyz_d50();
-        CieLab::from_xyz(xyz, xyzn).unwrap()
-    }
-
-    /// Returns the wavelength range (in nanometer) for the _horse shoe_,
-    /// the boundary of the area of all physical colors in a chromiticity diagram,
-    /// for this observer.
-    ///
-    /// Spectral locus points tend to freeze, or even fold back to lower wavelength
-    /// values at the blue and red perimeter ends. This can be quite anoying, for
-    /// example when trying to calculate dominant wavelength, or when creating
-    /// plots.
-    /// See Wikipedia's [CIE 1931 Color Space](https://en.wikipedia.org/wiki/CIE_1931_color_space).
-    ///
-    /// To help with the above problem, this method returns the wavelength range
-    /// for which the spectral locus points are unique, meaning
-    /// each wavelength has a chromaticity coordinate different from the wavelength
-    /// below or above it.
-    ///
-    /// To get the tristimulus values of the spectral locus, use
-    /// [`xyz_at_wavelength`](Self::xyz_at_wavelength).
-    pub fn spectral_locus_wavelength_range(&self) -> RangeInclusive<usize> {
-        self.spectral_locus_range.clone()
-    }
-
-    /// Calculates the RGB to XYZ matrix, for a particular color space.
-    pub fn rgb2xyz(&self, rgbspace: RgbSpace) -> Matrix3<f64> {
-        let space = rgbspace.data();
-        let mut rgb2xyz = Matrix3::from_iterator(
-            space
-                .primaries
-                .iter()
-                .flat_map(|s| self.xyz_from_spectrum(s).set_illuminance(1.0).values()),
-        );
-        let xyzw = self.xyz(&space.white, None).set_illuminance(1.0);
-        let decomp = rgb2xyz.lu();
-        // unwrap: only used with library color spaces
-        let rgbw = decomp.solve(&xyzw.xyz).unwrap();
-        for (i, mut col) in rgb2xyz.column_iter_mut().enumerate() {
-            col *= rgbw[i];
-        }
-        rgb2xyz
-    }
-
-    /// Calculates the XYZ to RGB matrix, for a particular color space.
-    pub fn xyz2rgb(&self, rgbspace: RgbSpace) -> Matrix3<f64> {
-        // unwrap: only used with library color spaces
-        self.rgb2xyz(rgbspace).try_inverse().unwrap()
-    }
-
-    /// Calculates the XYZ tristimulus values for a spectrum defined by a function.
-    ///
-    /// The input function `f` should accept a floating-point value in the range `[0.0, 1.0]`,
-    /// where `0.0` corresponds to a wavelength of 380 nm and `1.0` to 780 nm.
-    /// The function will be called once for each wavelength step (401 times at 1 nm intervals).
-    ///
-    /// # Arguments
-    /// * `f` - A function that takes a floating-point value in the range `[0.0, 1.0]` and returns
-    ///   the spectral value at that wavelength, in units of watts per square meter per nanometer (W/m²/nm) for
-    ///   illuminants, or Watts per square meter per steradian per nanometer (W/m²/sr/nm) for stimuli.
-    ///
-    /// # Notes
-    /// - This method is used in the library to compute the Planckian locus (the color of blackbody
-    ///   radiators), as described by Planck's law.
-    /// - For colorants, use [`xyz_from_colorant_fn`](Self::xyz_from_colorant_fn).
-    pub fn xyz_from_fn(&self, f: impl Fn(f64) -> f64) -> XYZ {
-        let xyz = self
-            .data
-            .column_iter()
-            .enumerate()
-            .fold(Vector3::zeros(), |acc, (i, cmf)| {
-                acc + cmf * f(i as f64 / (NS - 1) as f64)
-            });
-        XYZ {
-            xyz,
-            observer: self.tag,
-        }
-    }
-
-    /// Calculates XYZ tristimulus values for an analytic representation of a spectral distribution of
-    /// a filter or a color patch, using a normalized wavelength domain ranging from a value of 0.0 to 1.0,
-    /// illuminated with a standard illuminant.
-    ///
-    /// The spectral values should be defined within a range from 0.0 to 1.0, and are clamped otherwise.
-    /// The resulting XYZ value will have relative Y values in the range from 0 to 100.0.
-    ///
-    /// # Examples
-    /// A linear high pass filter, with a value of 0.0 for a wavelength of 380nm, and a value of 1.0 for 780nm,
-    /// and converting the resulting value to RGB values.
-    /// ```
-    /// use colorimetry::prelude::*;
-    /// let rgb: [u8;3] = CIE1931.xyz_from_colorant_fn(&CieIlluminant::D65, |x|x).rgb(None).clamp().into();
-    /// assert_eq!(rgb, [212, 171, 109]);
-    /// ```
-    /// Linear low pass filter, with a value of 1.0 for a wavelength of 380nm, and a value of 0.0 for 780nm,
-    /// and converting the resulting value to RGB values.
-    /// ```
-    /// use colorimetry::prelude::*;
-    /// let rgb: [u8;3] = CIE1931.xyz_from_colorant_fn(&CieIlluminant::D65, |x|1.0-x).rgb(None).clamp().into();
-    /// assert_eq!(rgb, [158, 202, 237]);
-    /// ```
-    pub fn xyz_from_colorant_fn(&self, illuminant: &CieIlluminant, f: impl Fn(f64) -> f64) -> XYZ {
-        let ill = illuminant.illuminant();
-        let xyzn = self.xyz_cie_table(illuminant, None);
-        let xyz = self
-            .data
-            .column_iter()
-            .zip(ill.0 .0.iter())
-            .enumerate()
-            .fold(Vector3::zeros(), |acc, (i, (cmfi, sv))| {
-                acc + cmfi * f(i as f64 / (NS - 1) as f64).clamp(0.0, 1.0) * *sv
-            });
-        let scale = 100.0 / xyzn.xyz.y;
-        XYZ {
-            xyz: xyz * self.lumconst * scale,
-            observer: self.tag,
-        }
-    }
 }
 
 #[cfg(test)]
 mod obs_test {
 
-    use super::Observer;
-    use crate::prelude::{CieIlluminant, CIE1931};
+    use super::{Observer, Observer::Cie1931, Observer::Cie1964};
+    use crate::illuminant::CieIlluminant;
     use crate::rgb::RgbSpace;
     use crate::spectrum::SPECTRUM_WAVELENGTH_RANGE;
     use crate::xyz::XYZ;
@@ -469,15 +421,15 @@ mod obs_test {
 
     #[test]
     fn test_cie1931_spectral_locus_min_max() {
-        let wavelength_lange = CIE1931.spectral_locus_wavelength_range();
-        let chromaticity = CIE1931
+        let wavelength_lange = Cie1931.spectral_locus_wavelength_range();
+        let chromaticity = Cie1931
             .xyz_at_wavelength(*wavelength_lange.start())
             .unwrap()
             .chromaticity();
         assert_ulps_eq!(chromaticity.x(), 0.17411, epsilon = 1E-5);
         assert_ulps_eq!(chromaticity.y(), 0.00496, epsilon = 1E-5);
 
-        let chromaticity = CIE1931
+        let chromaticity = Cie1931
             .xyz_at_wavelength(*wavelength_lange.end())
             .unwrap()
             .chromaticity();
@@ -489,7 +441,7 @@ mod obs_test {
     #[test]
     fn test_spectral_locus_full() {
         for observer in Observer::iter() {
-            let wavelength_range = observer.data().spectral_locus_wavelength_range();
+            let wavelength_range = observer.spectral_locus_wavelength_range();
 
             // Basic sanity checking of the spectral locus wavelength range values
             assert!(wavelength_range.start() >= SPECTRUM_WAVELENGTH_RANGE.start());
@@ -498,7 +450,7 @@ mod obs_test {
 
             // Check that xyz_at_wavelength returns sane values in the allowed range
             for wavelength in wavelength_range {
-                let xyz = observer.data().xyz_at_wavelength(wavelength).unwrap();
+                let xyz = observer.xyz_at_wavelength(wavelength).unwrap();
                 let chromaticity = xyz.chromaticity();
                 assert!((0.0..=1.0).contains(&chromaticity.x()));
                 assert!((0.0..=1.0).contains(&chromaticity.y()));
@@ -515,8 +467,8 @@ mod obs_test {
     fn test_spectral_locus_to_rgb() {
         for observer in Observer::iter() {
             eprintln!("Testing observer {:?}", observer);
-            for wavelength in observer.data().spectral_locus_wavelength_range() {
-                let xyz = observer.data().xyz_at_wavelength(wavelength).unwrap();
+            for wavelength in observer.spectral_locus_wavelength_range() {
+                let xyz = observer.xyz_at_wavelength(wavelength).unwrap();
                 for rgbspace in RgbSpace::iter() {
                     let _rgb = xyz.rgb(Some(rgbspace));
                 }
@@ -540,7 +492,7 @@ mod obs_test {
             0.4124564, 0.3575761, 0.1804375, 0.2126729, 0.7151522, 0.0721750, 0.0193339, 0.1191920,
             0.9503041,
         );
-        let got = CIE1931.rgb2xyz(crate::rgb::RgbSpace::SRGB);
+        let got = Cie1931.rgb2xyz(crate::rgb::RgbSpace::SRGB);
         approx::assert_ulps_eq!(want, got, epsilon = 3E-4);
     }
 
@@ -552,7 +504,7 @@ mod obs_test {
             3.2404542, -1.5371385, -0.4985314, -0.9692660, 1.8760108, 0.0415560, 0.0556434,
             -0.2040259, 1.0572252,
         );
-        let got = CIE1931.xyz2rgb(crate::rgb::RgbSpace::SRGB);
+        let got = Cie1931.xyz2rgb(crate::rgb::RgbSpace::SRGB);
         approx::assert_ulps_eq!(want, got, epsilon = 3E-4);
     }
 
@@ -575,13 +527,13 @@ mod obs_test {
     fn test_planckian_locus() {
         // see https://www.waveformlighting.com/tech/calculate-cie-1931-xy-coordinates-from-cct
         // for test data (not clear what CMF domain they use)
-        let xy = CIE1931
+        let xy = Cie1931
             .xyz_planckian_locus(3000.0)
             .chromaticity()
             .to_array();
         approx::assert_abs_diff_eq!(&xy.as_ref(), &[0.43693, 0.40407].as_ref(), epsilon = 2E-5);
 
-        let xy = CIE1931
+        let xy = Cie1931
             .xyz_planckian_locus(6500.0)
             .chromaticity()
             .to_array();
@@ -590,8 +542,8 @@ mod obs_test {
 
     #[test]
     fn test_xyz_from_illuminant_x_fn() {
-        let xyz = CIE1931.xyz_from_colorant_fn(&CieIlluminant::D65, |_v| 1.0);
-        let d65xyz = CIE1931.xyz_d65().xyz;
+        let xyz = Cie1931.xyz_from_colorant_fn(&CieIlluminant::D65, |_v| 1.0);
+        let d65xyz = Cie1931.xyz_d65().xyz;
         approx::assert_ulps_eq!(
             xyz,
             crate::xyz::XYZ::from_vecs(d65xyz, crate::observer::Observer::Cie1931)
@@ -601,25 +553,25 @@ mod obs_test {
     #[test]
     fn test_xyz_of_sample_with_standard_illuminant() {
         use crate::prelude::CieIlluminant::D65 as d65;
-        let xyz = CIE1931
+        let xyz = Cie1931
             .xyz(&d65, Some(&crate::colorant::Colorant::white()))
             .set_illuminance(100.0);
-        approx::assert_ulps_eq!(xyz, CIE1931.xyz_from_colorant_fn(&d65, |_| 1.0));
+        approx::assert_ulps_eq!(xyz, Cie1931.xyz_from_colorant_fn(&d65, |_| 1.0));
 
-        let xyz = CIE1931.xyz(&d65, Some(&crate::colorant::Colorant::black()));
-        approx::assert_ulps_eq!(xyz, CIE1931.xyz_from_colorant_fn(&d65, |_| 0.0));
+        let xyz = Cie1931.xyz(&d65, Some(&crate::colorant::Colorant::black()));
+        approx::assert_ulps_eq!(xyz, Cie1931.xyz_from_colorant_fn(&d65, |_| 0.0));
     }
 
     #[test]
     fn test_xyz_d65_d50() {
-        let cie1931_d65_xyz = crate::observer::CIE1931.xyz_d65();
+        let cie1931_d65_xyz = Cie1931.xyz_d65();
         approx::assert_ulps_eq!(
             cie1931_d65_xyz.values().as_ref(),
             [95.047, 100.0, 108.883].as_ref(),
             epsilon = 5E-2
         );
 
-        let cie1931_d50_xyz = crate::observer::CIE1931.xyz_d50();
+        let cie1931_d50_xyz = Cie1931.xyz_d50();
         approx::assert_ulps_eq!(
             cie1931_d50_xyz.values().as_ref(),
             [96.421, 100.0, 82.519].as_ref(),
@@ -630,14 +582,14 @@ mod obs_test {
     #[test]
     #[cfg(feature = "supplemental-observers")]
     fn test_xyz_d65_d50_cie1964() {
-        let cie1964_d50_xyz = crate::observer::CIE1964.xyz_d50();
+        let cie1964_d50_xyz = Cie1964.xyz_d50();
         approx::assert_ulps_eq!(
             cie1964_d50_xyz.values().as_ref(),
             [96.720, 100.0, 81.427].as_ref(),
             epsilon = 5E-2
         );
 
-        let cie1964_d65_xyz = crate::observer::CIE1964.xyz_d65();
+        let cie1964_d65_xyz = Cie1964.xyz_d65();
         approx::assert_ulps_eq!(
             cie1964_d65_xyz.values().as_ref(),
             [94.811, 100.0, 107.304].as_ref(),

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -76,7 +76,6 @@ use strum_macros::EnumIter;
 ///
 ///     It's main purpose is to calculate `XYZ` tristimulus values for a general stimulus,
 ///     in from of a `Spectrum`.
-
 struct ObserverData {
     data: SMatrix<f64, 3, NS>,
     lumconst: f64,
@@ -408,9 +407,9 @@ impl fmt::Display for Observer {
 #[cfg(test)]
 mod obs_test {
 
-    use super::{Observer, Observer::Cie1931};
     #[cfg(feature = "supplemental-observers")]
     use super::Observer::Cie1964;
+    use super::{Observer, Observer::Cie1931};
     use crate::illuminant::CieIlluminant;
     use crate::rgb::RgbSpace;
     use crate::spectrum::SPECTRUM_WAVELENGTH_RANGE;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -156,7 +156,7 @@ impl Observer {
     pub fn name(&self) -> &'static str {
         self.data().name
     }
-    
+
     /// Calulates Tristimulus values for an object implementing the [Light] trait, and an optional [Filter],
     /// filtering the light.
     ///
@@ -304,7 +304,6 @@ impl Observer {
         // unwrap: only used with library color spaces
         self.rgb2xyz(rgbspace).try_inverse().unwrap()
     }
-
 
     /// Returns the wavelength range (in nanometer) for the _horse shoe_,
     /// the boundary of the area of all physical colors in a chromiticity diagram,

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -5,7 +5,7 @@ use crate::{
     spectrum::NS,
 };
 
-pub(crate) static CIE1931: ObserverData = ObserverData::new(
+pub(super) static CIE1931: ObserverData = ObserverData::new(
     Observer::Cie1931,
     "CIE 1931 2°",
     683.0,
@@ -416,7 +416,7 @@ pub(crate) static CIE1931: ObserverData = ObserverData::new(
 );
 
 #[cfg(feature = "supplemental-observers")]
-pub(crate) static CIE1964: ObserverData = ObserverData::new(
+pub(super) static CIE1964: ObserverData = ObserverData::new(
     Observer::Cie1964,
     "CIE 1964 10°",
     683.0,
@@ -827,7 +827,7 @@ pub(crate) static CIE1964: ObserverData = ObserverData::new(
 );
 
 #[cfg(feature = "supplemental-observers")]
-pub(crate) static CIE2015: ObserverData = ObserverData::new(
+pub(super) static CIE2015: ObserverData = ObserverData::new(
     Observer::Cie2015,
     "CIE 2015 2°",
     683.0,
@@ -1261,7 +1261,7 @@ pub(crate) static CIE2015: ObserverData = ObserverData::new(
 /// This dataset is intended for spectral color calculations involving wider visual fields and is especially
 /// relevant for applications in display technology, lighting design, and colorimetry where larger visual fields
 /// are encountered.
-pub(crate) static CIE2015_10: ObserverData = ObserverData::new(
+pub(super) static CIE2015_10: ObserverData = ObserverData::new(
     Observer::Cie2015_10,
     "CIE 2015 10°",
     683.0,

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -1706,7 +1706,7 @@ mod tests {
         let max = spectral_locus_index_max(observer) + SPECTRUM_WAVELENGTH_RANGE.start();
         assert!(min >= *SPECTRUM_WAVELENGTH_RANGE.start());
         assert!(max <= *SPECTRUM_WAVELENGTH_RANGE.end());
-        assert_eq!(min..=max, observer.data().spectral_locus_wavelength_range());
+        assert_eq!(min..=max, observer.spectral_locus_wavelength_range());
     }
 
     /// The index value of the blue spectral locus edge.

--- a/src/observer/observers.rs
+++ b/src/observer/observers.rs
@@ -5,7 +5,7 @@ use crate::{
     spectrum::NS,
 };
 
-pub static CIE1931: ObserverData = ObserverData::new(
+pub(crate) static CIE1931: ObserverData = ObserverData::new(
     Observer::Cie1931,
     "CIE 1931 2°",
     683.0,
@@ -416,7 +416,7 @@ pub static CIE1931: ObserverData = ObserverData::new(
 );
 
 #[cfg(feature = "supplemental-observers")]
-pub static CIE1964: ObserverData = ObserverData::new(
+pub(crate) static CIE1964: ObserverData = ObserverData::new(
     Observer::Cie1964,
     "CIE 1964 10°",
     683.0,
@@ -827,7 +827,7 @@ pub static CIE1964: ObserverData = ObserverData::new(
 );
 
 #[cfg(feature = "supplemental-observers")]
-pub static CIE2015: ObserverData = ObserverData::new(
+pub(crate) static CIE2015: ObserverData = ObserverData::new(
     Observer::Cie2015,
     "CIE 2015 2°",
     683.0,
@@ -1261,7 +1261,7 @@ pub static CIE2015: ObserverData = ObserverData::new(
 /// This dataset is intended for spectral color calculations involving wider visual fields and is especially
 /// relevant for applications in display technology, lighting design, and colorimetry where larger visual fields
 /// are encountered.
-pub static CIE2015_10: ObserverData = ObserverData::new(
+pub(crate) static CIE2015_10: ObserverData = ObserverData::new(
     Observer::Cie2015_10,
     "CIE 2015 10°",
     683.0,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,7 +21,7 @@
 //! - **CIELab & Delta-E**  
 //!   - `CieLab` and color-difference formulas (Euclidean ΔE*ab, CIEDE2000).  
 //! - **Observers**  
-//!   - Standard observers (CIE1931, CIE1964, CIE2015 cone fundamentals).  
+//!   - Standard observers CIE1931
 //! - **Physics**  
 //!   - Radiometric constants (Planck’s law, Stefan–Boltzmann), Gaussian helpers, wavelength converters.  
 //! - **RGB Color**  
@@ -36,7 +36,7 @@ pub use super::cam::{CamTransforms, CieCam16, ViewConditions};
 pub use super::colorant::Colorant;
 pub use super::illuminant::{CieIlluminant, Illuminant};
 pub use super::lab::CieLab;
-pub use super::observer::{Observer, CIE1931};
+pub use super::observer::{Observer, Observer::Cie1931};
 pub use super::rgb::{Rgb, RgbSpace, WideRgb};
 pub use super::spectrum::Spectrum;
 pub use super::stimulus::Stimulus;

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -217,7 +217,7 @@ impl Rgb {
     /// Converts the RGB value to a tri-stimulus XYZ value
     pub fn xyz(&self) -> XYZ {
         const YW: f64 = 100.0;
-        let xyz = self.observer.data().rgb2xyz(self.space) * self.rgb;
+        let xyz = self.observer.rgb2xyz(self.space) * self.rgb;
         XYZ {
             observer: self.observer,
             xyz: xyz.map(|v| v * YW),
@@ -249,7 +249,7 @@ impl Light for Rgb {
     /// - The observer's data is used to apply luminance scaling, enhancing perceptual accuracy.
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = &self.space.data().primaries;
-        let rgb2xyz = self.observer.data().rgb2xyz(self.space);
+        let rgb2xyz = self.observer.rgb2xyz(self.space);
         let yrgb = rgb2xyz.row(1);
         //        self.rgb.iter().zip(yrgb.iter()).zip(prim.iter()).map(|((v,w),s)|*v * *w * &s.0).sum()
         let s = self
@@ -306,7 +306,7 @@ impl Filter for Rgb {
     ///   that can be combined with any illuminant to produce a specific stimulus.
     fn spectrum(&self) -> Cow<Spectrum> {
         let prim = self.space.data().primaries_as_colorants();
-        let rgb2xyz = self.observer.data().rgb2xyz(self.space);
+        let rgb2xyz = self.observer.rgb2xyz(self.space);
         let yrgb = rgb2xyz.row(1);
         let s = self
             .rgb

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -287,8 +287,8 @@ impl Filter for Rgb {
     /// let spectrum = Filter::spectrum(&rgb);
     ///
     /// // Compare with the CIE D65 reference white point
-    /// let d65: XYZ = CIE1931.xyz(&CieIlluminant::D65, Some(&rgb));
-    /// let xyz_d65 = CIE1931.xyz_d65();
+    /// let d65: XYZ = Cie1931.xyz(&CieIlluminant::D65, Some(&rgb));
+    /// let xyz_d65 = Cie1931.xyz_d65();
     /// approx::assert_ulps_eq!(d65, xyz_d65, epsilon = 1e-2);
     /// ```
     ///

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -257,6 +257,7 @@ impl RgbSpaceData {
 #[cfg(test)]
 mod rgbspace_tests {
     use crate::prelude::*;
+    use Observer::Cie1931;
     use approx::assert_ulps_eq;
     use strum::IntoEnumIterator;
 
@@ -271,7 +272,7 @@ mod rgbspace_tests {
 
             let iter = primaries_chromaticity.into_iter().zip(primaries_colorants);
             for (chromaticity, colorant) in iter {
-                let computed_chromaticity = CIE1931
+                let computed_chromaticity = Cie1931
                     .xyz_from_spectrum(&colorant.spectrum())
                     .chromaticity();
                 assert_ulps_eq!(

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -257,9 +257,9 @@ impl RgbSpaceData {
 #[cfg(test)]
 mod rgbspace_tests {
     use crate::prelude::*;
-    use Observer::Cie1931;
     use approx::assert_ulps_eq;
     use strum::IntoEnumIterator;
+    use Observer::Cie1931;
 
     #[test]
     /// Check color points of the primaries, as calculated from the space's

--- a/src/rgb/widergb.rs
+++ b/src/rgb/widergb.rs
@@ -121,7 +121,7 @@ impl WideRgb {
     /// Converts the RGB value to a tri-stimulus XYZ value
     pub fn xyz(&self) -> XYZ {
         const YW: f64 = 100.0;
-        let xyz = self.observer.data().rgb2xyz(self.space) * self.rgb;
+        let xyz = self.observer.rgb2xyz(self.space) * self.rgb;
         XYZ {
             observer: self.observer,
             xyz: xyz.map(|v| v * YW),

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -1,4 +1,5 @@
-//! # Basis for Spectral Data Representations
+//! Basis for Spectral Data Representations
+//! =======================================
 //!
 //! The field of Colorimetry uses mathematical models to describe the sensations in our mind which we
 //! call color.  These models are based the spectral composition of stimuli, essentially rays of light

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -503,13 +503,13 @@ mod tests {
     fn test_spectrum_from_rgb() {
         let white: Stimulus = Rgb::new(1.0, 1.0, 1.0, None, None).unwrap().into();
         approx::assert_ulps_eq!(
-            CIE1931.xyz_from_spectrum(&white),
-            CIE1931.xyz_d65().set_illuminance(100.0),
+            Cie1931.xyz_from_spectrum(&white),
+            Cie1931.xyz_d65().set_illuminance(100.0),
             epsilon = 1E-6
         );
         let red = Stimulus::from_srgb(255, 0, 0);
         assert_ulps_eq!(
-            CIE1931
+            Cie1931
                 .xyz_from_spectrum(&red)
                 .chromaticity()
                 .to_array()
@@ -528,11 +528,11 @@ mod tests {
 
     #[test]
     fn test_chromaticity() {
-        let xyz0 = CIE1931.xyz_from_spectrum(D65.as_ref());
+        let xyz0 = Cie1931.xyz_from_spectrum(D65.as_ref());
         let [x0, y0] = xyz0.chromaticity().to_array();
 
         let d65 = D65.clone().set_illuminance(Cie1931, 100.0);
-        let xyz = CIE1931.xyz_from_spectrum(d65.as_ref());
+        let xyz = Cie1931.xyz_from_spectrum(d65.as_ref());
         let [x, y] = xyz.chromaticity().to_array();
 
         assert_ulps_eq!(x0, x);
@@ -586,7 +586,7 @@ mod tests {
 
     #[test]
     fn ee() {
-        let chromaticity = CIE1931
+        let chromaticity = Cie1931
             .xyz_from_spectrum(
                 Illuminant::equal_energy()
                     .set_illuminance(Cie1931, 100.0)
@@ -599,7 +599,7 @@ mod tests {
 
     #[test]
     fn d65() {
-        let chromaticity = CIE1931
+        let chromaticity = Cie1931
             .xyz_from_spectrum(Illuminant::d65().set_illuminance(Cie1931, 100.0).as_ref())
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)
@@ -617,7 +617,7 @@ mod tests {
 
     #[test]
     fn d50() {
-        let chromaticity = CIE1931
+        let chromaticity = Cie1931
             .xyz_from_spectrum(Illuminant::d50().set_illuminance(Cie1931, 100.0).as_ref())
             .chromaticity();
         // See table T3 CIE15:2004 (calculated with 5nm intervals, instead of 1nm, as used here)

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -25,7 +25,7 @@ impl Stimulus {
 
     /// Sets the luminance of the stimulus based on the observer data and a luminance value.
     pub fn set_luminance(mut self, obs: Observer, luminance: f64) -> Self {
-        let y = obs.data().y_from_spectrum(self.as_ref());
+        let y = obs.y_from_spectrum(self.as_ref());
         let l = luminance / y;
         self.0 .0.iter_mut().for_each(|v| *v *= l);
         self
@@ -79,7 +79,7 @@ impl Sum for Stimulus {
 impl From<Rgb> for Stimulus {
     fn from(rgb: Rgb) -> Self {
         let prim = &rgb.space.data().primaries;
-        let rgb2xyz = rgb.observer.data().rgb2xyz(rgb.space);
+        let rgb2xyz = rgb.observer.rgb2xyz(rgb.space);
         let yrgb = rgb2xyz.row(1);
         rgb.rgb
             .iter()

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -1,3 +1,33 @@
+//! Spectral Power Distributions for Visible Light Stimuli
+//! ======================================================
+//!
+//! This module defines the [`Stimulus`] struct, which represents the spectral power
+//! distribution of a visible light stimulus—such as a pixel on a screen—using a [`Spectrum`].
+//!
+//! A `Stimulus` is typically constructed from RGB values using `from_srgb` or `from_rgb`,
+//! mapping them to a linear combination of spectral primaries defined by a color space
+//! (e.g., sRGB with Gaussian-filtered components). These spectral primaries allow for
+//! physically-informed color calculations that are observer-aware.
+//!
+//! Unlike traditional RGB or XYZ values, a `Stimulus` retains full spectral detail,
+//! enabling colorimetric computations for arbitrary [`Observer`] types,
+//! not just the standard CIE 1931 observer.
+//!
+//! ## Features
+//! - Convert RGB values into spectral representations.
+//! - Scale to a target luminance using real observer sensitivity curves.
+//! - Integrates with the [`Light`] trait for uniform handling of illuminants and reflectances.
+//!
+//! ## When to Use `Stimulus`
+//! Use `Stimulus` when:
+//! - You need to model light with spectral fidelity.
+//! - You want to convert RGB colors to spectra for metamerism studies or non-standard observers.
+//! - You need to simulate how different humans perceive color.
+//!
+//! [`Spectrum`]: crate::spectrum::Spectrum
+//! [`Observer`]: crate::observer::Observer
+//! [`Light`]: crate::traits::Light
+
 use std::{
     borrow::Cow,
     iter::Sum,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -17,7 +17,7 @@ pub trait Light {
     /// The illuminance value is optional, and if not provided, the actual luminous values in the
     /// spectrum are used.
     fn xyzn(&self, observer: Observer, y: Option<f64>) -> XYZ {
-        let xyz = observer.data().xyz_from_spectrum(&self.spectrum());
+        let xyz = observer.xyz_from_spectrum(&self.spectrum());
         if let Some(illuminance) = y {
             xyz.set_illuminance(illuminance)
         } else {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,31 @@
+//! Traits for spectrally-defined light sources and partially absorbing media
+//! =========================================================================
+//!
+//! This module defines two key traits:
+//!
+//! - [`Light`]: a trait for anything that emits and can be described by a spectral power distribution.
+//! - [`Filter`]: a trait for anything that (partially) absorbs light spectra, such as dyes and pigments.
+//!
+//! The [`Light`] trait is primarily used to represent illuminants or display pixel emissions,
+//! providing tristimulus values for a given [`Observer`] through spectral integration.
+//! This enables color calculations that are not limited to the CIE 1931 standard observer,
+//! allowing modeling for animal vision, wide-field observers, or custom visual systems.
+//!
+//! You can implement `Light` for types that contain or can generate a [`Spectrum`].
+//! For standard illuminants like D65, the trait is often implemented using lookup tables
+//! or hard-coded spectral curves via the [`Illuminant`] type.
+//!
+//! ## Conversion
+//! Any `Light` can be converted into an [`Illuminant`] using the `From` implementation.
+//!
+//! ## Related Types
+//! - [`Spectrum`]: Represents sampled spectral data across wavelengths.
+//! - [`Observer`]: Encapsulates color matching functions for various observers.
+//! - [`Illuminant`]: Represents standard light sources such as D65 or A.
+//!
+//! [`Spectrum`]: crate::spectrum::Spectrum
+//! [`Observer`]: crate::observer::Observer
+//! [`Illuminant`]: crate::illuminant::Illuminant
 use std::borrow::Cow;
 
 use crate::{illuminant::Illuminant, observer::Observer, spectrum::Spectrum, xyz::XYZ};

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -300,7 +300,7 @@ impl XYZ {
         let space = space.unwrap_or_default();
         let xyz = self.xyz;
         let d = xyz.map(|v| v / 100.0); // normalize to 1.0
-        let data = self.observer.data().xyz2rgb(space) * d;
+        let data = self.observer.xyz2rgb(space) * d;
         WideRgb {
             space,
             observer: self.observer,
@@ -382,7 +382,7 @@ mod xyz_test {
 
     #[test]
     fn xyz_d65_test() {
-        let d65 = CIE1931.xyz_d65();
+        let d65 = Cie1931.xyz_d65();
         let xyz: [f64; 3] = d65.into();
         println!("{xyz:?}");
         assert_ulps_eq!(

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -1,5 +1,5 @@
-//! Tristimulus Values
-//! ==================
+//! Tristimulus Values Calculations and Models
+//! ==========================================
 //!
 //! The `xyz` module provides core types and operations for working with CIE tristimulus values (X,
 //! Y, Z) and chromaticity in Rust.  

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -176,7 +176,7 @@ impl XYZ {
     /// use colorimetry::prelude::*;
     /// use approx::assert_ulps_eq;
     ///
-    /// let d65_xyz = CIE1931.xyz(&CieIlluminant::D65, None).set_illuminance(100.0);
+    /// let d65_xyz = Cie1931.xyz(&CieIlluminant::D65, None).set_illuminance(100.0);
     /// let [x, y, z] = d65_xyz.values();
     /// // Calculated Spreadsheet Values from CIE Datasets, over a range from 380 to 780nm
     /// assert_ulps_eq!(x, 95.042_267, epsilon = 1E-6);
@@ -194,11 +194,11 @@ impl XYZ {
     /// use approx::assert_ulps_eq;
     /// const D65A: [f64;3] = [95.04, 100.0, 108.86];
     ///
-    /// let d65_xyz = CIE1931.xyz(&CieIlluminant::D65, None).set_illuminance(100.0);
+    /// let d65_xyz = Cie1931.xyz(&CieIlluminant::D65, None).set_illuminance(100.0);
     /// assert_ulps_eq!(d65_xyz, XYZ::new(D65A, Observer::Cie1931), epsilon = 1E-2);
     ///
-    /// let d65_xyz_sample = CIE1931.xyz(&CieIlluminant::D65, Some(&Colorant::white()));
-    /// assert_ulps_eq!(d65_xyz_sample, XYZ::new(D65A, Observer::Cie1931), epsilon = 1E-2);
+    /// let d65_xyz_sample = Cie1931.xyz(&CieIlluminant::D65, Some(&Colorant::white()));
+    /// assert_ulps_eq!(d65_xyz_sample, XYZ::new(D65A, Cie1931), epsilon = 1E-2);
     /// ```
     pub fn set_illuminance(mut self, illuminance: f64) -> Self {
         if self.xyz.y > f64::EPSILON && illuminance > f64::EPSILON {
@@ -216,7 +216,7 @@ impl XYZ {
     /// use colorimetry::prelude::*;
     /// use approx::assert_ulps_eq;
     ///
-    /// let d65_xyz = CIE1931.xyz(&CieIlluminant::D65, None);
+    /// let d65_xyz = Cie1931.xyz(&CieIlluminant::D65, None);
     /// let chromaticity = d65_xyz.chromaticity();
     /// assert_ulps_eq!(chromaticity.to_array().as_ref(), [0.312_738, 0.329_052].as_slice(), epsilon = 1E-6);
     /// ```

--- a/src/xyz/dominant.rs
+++ b/src/xyz/dominant.rs
@@ -20,7 +20,7 @@ impl XYZ {
     ///
     pub fn dominant_wavelength(&self, white: XYZ) -> Result<f64, Error> {
         let mut sign = 1.0;
-        let wavelength_range = self.observer.data().spectral_locus_wavelength_range();
+        let wavelength_range = self.observer.spectral_locus_wavelength_range();
         let mut low = *wavelength_range.start();
         let mut high = *wavelength_range.end();
         let mut mid = 540usize; // 200 fails, as its tail overlaps into the blue region
@@ -34,7 +34,6 @@ impl XYZ {
             let blue_edge = LineAB::new(
                 white_chromaticity.to_array(),
                 self.observer
-                    .data()
                     .xyz_at_wavelength(low)
                     .unwrap()
                     .chromaticity()
@@ -44,7 +43,6 @@ impl XYZ {
             let red_edge = LineAB::new(
                 white_chromaticity.to_array(),
                 self.observer
-                    .data()
                     .xyz_at_wavelength(high)
                     .unwrap()
                     .chromaticity()
@@ -67,7 +65,6 @@ impl XYZ {
                 let bisect = LineAB::new(
                     white_chromaticity.to_array(),
                     self.observer
-                        .data()
                         .xyz_at_wavelength(mid)
                         .unwrap()
                         .chromaticity()
@@ -91,7 +88,6 @@ impl XYZ {
                 let low_ab = LineAB::new(
                     white.chromaticity().to_array(),
                     self.observer
-                        .data()
                         .xyz_at_wavelength(low)
                         .unwrap()
                         .chromaticity()
@@ -102,7 +98,6 @@ impl XYZ {
                 let high_ab = LineAB::new(
                     white.chromaticity().to_array(),
                     self.observer
-                        .data()
                         .xyz_at_wavelength(high)
                         .unwrap()
                         .chromaticity()
@@ -130,10 +125,10 @@ mod xyz_test {
 
     #[test]
     fn dominant_wavelength_test() {
-        let d65 = CIE1931.xyz_d65().set_illuminance(50.0);
+        let d65 = Cie1931.xyz_d65().set_illuminance(50.0);
 
         // 550 nm
-        let sl = CIE1931
+        let sl = Cie1931
             .xyz_at_wavelength(550)
             .unwrap()
             .set_illuminance(50.0);
@@ -142,7 +137,7 @@ mod xyz_test {
         assert_ulps_eq!(dl, 550.0);
 
         for wl in 380..=699usize {
-            let sl2 = CIE1931.xyz_at_wavelength(wl).unwrap();
+            let sl2 = Cie1931.xyz_at_wavelength(wl).unwrap();
             //let [slx, sly] = sl2.chromaticity();
             //println!("sl xy: {slx} {sly}");
             let dl = sl2.dominant_wavelength(d65).unwrap();
@@ -152,17 +147,17 @@ mod xyz_test {
 
     #[test]
     fn dominant_wavelength_purple_test() {
-        let d65 = CIE1931.xyz_d65();
+        let d65 = Cie1931.xyz_d65();
         let white_chromaticity = d65.chromaticity();
 
         // get purple line
-        let xyzb = CIE1931.xyz_at_wavelength(380).unwrap();
+        let xyzb = Cie1931.xyz_at_wavelength(380).unwrap();
         let [xb, yb] = xyzb.chromaticity().to_array();
-        let xyzr = CIE1931.xyz_at_wavelength(699).unwrap();
+        let xyzr = Cie1931.xyz_at_wavelength(699).unwrap();
         let [xr, yr] = xyzr.chromaticity().to_array();
         let line_t = LineAB::new([xb, yb], [xr, yr]).unwrap();
         for wl in 380..=699usize {
-            let sl = CIE1931.xyz_at_wavelength(wl).unwrap();
+            let sl = Cie1931.xyz_at_wavelength(wl).unwrap();
             let chromaticity = sl.chromaticity();
             let line_u =
                 LineAB::new(chromaticity.to_array(), white_chromaticity.to_array()).unwrap();


### PR DESCRIPTION
Following up on a suggestion from @faern.

This avoids further confusion with users about when to use `ObserverData` and `Observer`.

Additionally, I moved all implementations of `ObserverData` to `Observer` to avoid code duplication.