### PR TITLE
Adding Spectral Color Management Example on Colorimetry's main page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 
+### Documentation
+
 ### Added
 - `Gaussian` struct, to represent normal distributions as used in this library as spectral
   distributions and used for filtering.
@@ -21,6 +23,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add `CieCam02` implementation, with same methods as CieCam16.
 - Add `CFI` Color Fidelity Index calculations. with `general_color_fidelity_index` and `special_color_fidelity_indices`.
 - Add standard CIECAM viewing conditions as recommended by CIE248 as constants.
+- _Spectral RGB matching example_ to convert spectral reflectance into sRGB values using the CIE 2015 10° observer. 
+- New helper functions in the `cam` module (and submodules `cam02`, `cam16`, `viewconditions`) for spectral color appearance calculations and surround presets.
+- A comprehensive spectral _color management example_ in `README.md`, demonstrating matching the Munsell paint chip <i>5 BG 5/8</i> to its sRGB equivalent (LED_B2 illuminant, CIE 2015 10° observer).  [oai_citation:3‡github.com](https://github.com/harbik/colorimetry/pull/92/files)  
 
 ### Changed
 - Refactored `physics.rs` with the planck functions and LED functions now moved to the `Illuminant` module,
@@ -31,6 +36,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Replaced all instances of `&ObserverData` in the public API with `Observer`, which is an `enum`, to avoid confusion between the use of `ObserverData` and `Observer`.
 - Renamed `CieCam16::ciede2016` to `de_ucs`.
 - Replaced all instances of `&RgbSpace` in the API with `RgbSpace`, as both were used inconsistently.
+- Updated inline code comments for clarity in color conversion routines and view‐condition constructors.
+- Refined README section layout and wording to better guide users through the new spectral examples.
 
 ### Removed
 - Various normal distribution (gaussian) helper functions, now all collected as methods of the `Gaussian` struct.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ In practical terms, a ΔE of 3 is considered a close match—just at the thresho
 ```
 </details>
 
+<details>
+<summary><strong>Match a paint color to a <i>sRGB</i> display value under realistic viewing conditions</strong></summary>
+
+This example matches the Munsell paint chip “7.5 BG 7/8”—a light teal—to its nearest <i>sRGB</i>
+equivalent value under conditions that mimic real-world viewing. Instead of the traditional <i>CIE
+1931 2°</i> observer, we use the <i>CIE 2015 10° observer</i>, which better represents how paint
+colours appear at on a wall. We'll assume the paint is illuminated with the warm-white <i>LED_B2</i>
+standard illuminant (≈ 3000 K). Taken together, the display color matches what you’d see on
+a freshly painted wall.
+
+```rust
+    // requires `supplemental-observers`, and `munsell` features
+```
+</details>
+
 ## Features
 
 - [`Spectrum`] Standard fixed-grid spectral representation over a wavelength range from 380 to 780 nanometers, with 1-nanometer intervals.

--- a/README.md
+++ b/README.md
@@ -27,22 +27,22 @@ or add this line to the dependencies in your Cargo.toml file:
 This example calculates the XYZ tristimulus values of the D65 illuminant for both the CIE 1931 2º standard observer and the CIE 2015 10º observer.
 
 ```rust
-    use colorimetry::illuminant::D65;
+use colorimetry::illuminant::D65;
 
-    // D65 Tristimulus values, using the CIE1931 standard observer by default
-    let xyz_d65 = D65.xyz(None).set_illuminance(100.0);
+// D65 Tristimulus values, using the CIE1931 standard observer by default
+let xyz_d65 = D65.xyz(None).set_illuminance(100.0);
 
-    let [x, y, z] = xyz_d65.values();
-    // [95.04, 100.0, 108.86]
+let [x, y, z] = xyz_d65.values();
+// [95.04, 100.0, 108.86]
 
-    // D65 Tristimulus values using the CIE2015 10º observer
-    // This requires the `supplemental-observers` feature (enabled by default)
-    use colorimetry::observer::Observer::Cie2015_10;
-    let xyz_d65_10 = D65
-        .xyz(Some(Cie2015_10)).set_illuminance(100.0);
+// D65 Tristimulus values using the CIE2015 10º observer
+// This requires the `supplemental-observers` feature (enabled by default)
+use colorimetry::observer::Observer::Cie2015_10;
+let xyz_d65_10 = D65
+    .xyz(Some(Cie2015_10)).set_illuminance(100.0);
 
-    let [x_10, y_10, z_10] = xyz_d65_10.values();
-    //[94.72, 100.0, 107.143]
+let [x_10, y_10, z_10] = xyz_d65_10.values();
+//[94.72, 100.0, 107.143]
 ```
 </details>
 
@@ -56,12 +56,12 @@ This example calculates both the correlated color temperature and the deviation 
 locus, often referred to as the tint.
 
 ```rust
-    use colorimetry::illuminant::A;
+use colorimetry::illuminant::A;
 
-    // Calculate CCT and Duv for the A illuminant
-    // Requires `cct`, and `cie-illuminants` features
-    let [cct, duv] = A.cct().unwrap().values();
-    // [2855.4977, 0.0]
+// Calculate CCT and Duv for the A illuminant
+// Requires `cct`, and `cie-illuminants` features
+let [cct, duv] = A.cct().unwrap().values();
+// [2855.4977, 0.0]
 ```
 </details>
 
@@ -76,13 +76,13 @@ difference metrics, compared to the CRI’s use of only 8 samples.
 Below is an example calculation of the general Color Fidelity Index for the CIE F2 illuminant:
 
 ```rust
-    use colorimetry::illuminant::F2;
+use colorimetry::illuminant::F2;
 
-    // Calculate the Color Fidelity Index of the CIE F2 standard illuminant
-    // Requires `cfi`, and `cie-illuminants` features
-    let cf_f2 = F2.cfi().unwrap();
-    let cf = cf_f2.general_color_fidelity_index();
-    // 70.3
+// Calculate the Color Fidelity Index of the CIE F2 standard illuminant
+// Requires `cfi`, and `cie-illuminants` features
+let cf_f2 = F2.cfi().unwrap();
+let cf = cf_f2.general_color_fidelity_index();
+// 70.3
 ```
 </details>
 
@@ -96,16 +96,16 @@ physically realizable colors. Due to its shape, it is sometimes informally refer
 Below, we compute the chromaticity coordinates that define the spectral locus.
 
 ```rust
-    use colorimetry::observer::Observer::Cie1931;
-    let mut locus = Vec::new();
-    let wavelength_range = Cie1931.spectral_locus_wavelength_range();
-    for wavelength in wavelength_range {
-        // unwrap OK because nm is in range
-        let xyz = Cie1931.xyz_at_wavelength(wavelength).unwrap();
-        let chromaticity = xyz.chromaticity();
-        locus.push([wavelength as f64, chromaticity.x(), chromaticity.y()]);
-    }
-    println!("{locus:?}");
+use colorimetry::observer::Observer::Cie1931;
+let mut locus = Vec::new();
+let wavelength_range = Cie1931.spectral_locus_wavelength_range();
+for wavelength in wavelength_range {
+    // unwrap OK because nm is in range
+    let xyz = Cie1931.xyz_at_wavelength(wavelength).unwrap();
+    let chromaticity = xyz.chromaticity();
+    locus.push([wavelength as f64, chromaticity.x(), chromaticity.y()]);
+}
+println!("{locus:?}");
 ```
 </details>
 
@@ -116,26 +116,26 @@ Instead of fixed XYZ values, it computes conversions from the spectral definitio
 Here, we compute transformation matrices for the `DisplayP3` color space using both the `Cie1931` and `Cie2015` observers.
 
 ```rust
-    use colorimetry::observer::Observer;
-    use colorimetry::rgb::RgbSpace::DisplayP3;
+use colorimetry::observer::Observer;
+use colorimetry::rgb::RgbSpace::DisplayP3;
 
-    let xyz2rgb_31 = Observer::Cie1931.xyz2rgb(DisplayP3);
-        //  2.4933, -0.9313, -0.4027,
-        // -0.8298,  1.7629,  0.0236,
-        //  0.0355, -0.076,   0.9574
+let xyz2rgb_31 = Observer::Cie1931.xyz2rgb(DisplayP3);
+//  2.4933, -0.9313, -0.4027,
+// -0.8298,  1.7629,  0.0236,
+//  0.0355, -0.076,   0.9574
 
-    let rgb2xyz_31 = Observer::Cie1931.rgb2xyz(DisplayP3);
-        // 0.4866, 0.2656, 0.1981,
-        // 0.2291, 0.6917, 0.0792,
-        // 0.0001, 0.0451, 1.0433,
+let rgb2xyz_31 = Observer::Cie1931.rgb2xyz(DisplayP3);
+// 0.4866, 0.2656, 0.1981,
+// 0.2291, 0.6917, 0.0792,
+// 0.0001, 0.0451, 1.0433,
 
-    // requires `supplemental-observers`
-    use colorimetry::observer::Observer::Cie2015;
+// requires `supplemental-observers`
+use colorimetry::observer::Observer::Cie2015;
 
-    let xyz2rgb_15 = Cie2015.xyz2rgb(DisplayP3);
-        //  2.5258,  -1.0009, -0.3649,
-        // -0.9006,   1.8546, -0.0011,
-        //  0.0279,  -0.0574,  0.95874
+let xyz2rgb_15 = Cie2015.xyz2rgb(DisplayP3);
+//  2.5258,  -1.0009, -0.3649,
+// -0.9006,   1.8546, -0.0011,
+//  0.0279,  -0.0574,  0.95874
 ```
 </details>
 
@@ -149,34 +149,63 @@ The closest match identified is Munsell "5R 5/14", a vivid red hue, with a color
 In practical terms, a ΔE of 3 is considered a close match—just at the threshold where most observers might start to notice a difference under controlled viewing conditions.
 
 ```rust
-    // requires `cri`, `supplemental-observers`, and `munsell` features
-    use colorimetry::observer::Observer::Cie2015_10;
-    use colorimetry::colorant::{MunsellCollection, TCS};
+// requires `cri`, `supplemental-observers`, and `munsell` features
+use colorimetry::observer::Observer::Cie2015_10;
+use colorimetry::colorant::{MunsellCollection, TCS};
 
-    let cri_r9 = &TCS[8];
-    let (key, delta_e) = MunsellCollection::match_ciecam16(
-        cri_r9,
-        None,
-        None,
-        Some(Cie2015_10),
-    )
-    .unwrap();
-    // ("5R4/14", 3.0)
+let cri_r9 = &TCS[8];
+let (key, delta_e) = MunsellCollection::match_ciecam16(
+    cri_r9,
+    None,
+    None,
+    Some(Cie2015_10),
+)
+.unwrap();
+// ("5R4/14", 3.0)
 ```
 </details>
 
 <details>
 <summary><strong>Match a paint color to a <i>sRGB</i> display value under realistic viewing conditions</strong></summary>
 
-This example matches the Munsell paint chip “7.5 BG 7/8”—a light teal—to its nearest <i>sRGB</i>
-equivalent value under conditions that mimic real-world viewing. Instead of the traditional <i>CIE
-1931 2°</i> observer, we use the <i>CIE 2015 10° observer</i>, which better represents how paint
-colours appear at on a wall. We'll assume the paint is illuminated with the warm-white <i>LED_B2</i>
-standard illuminant (≈ 3000 K). Taken together, the display color matches what you’d see on
-a freshly painted wall.
+This example matches the Munsell paint chip <i>5 BG 5/8</i>—a teal/blue-green color—
+to its nearest <i>sRGB</i>
+<span style="display: inline-block; width: 1em; height: 1em; background-color: rgb(0, 113, 138);
+border-radius: 50%; vertical-align: middle; border: 1px solid #000;"></span>
+<span>rgb(0, 113, 138)</span>
+equivalent, mimicking real-world viewing conditions.
+
+Instead of the traditional <i>CIE 1931 2°</i> observer, this match uses the <i>CIE 2015 10° observer</i>,
+which more accurately reflects how paint colors appear on walls. The illumination is based on the warm-white
+<i>LED_B2</i> standard illuminant (≈ 3000 K). Together, these adjustments help the display color reflect
+what you'd actually see on a freshly painted surface.
 
 ```rust
-    // requires `supplemental-observers`, and `munsell` features
+// requires `supplemental-observers`, and `munsell` features
+use colorimetry::{
+    cam::{ViewConditions, CIE248_HOME_SCREEN},
+    colorant::Munsell,
+    illuminant::LED_B2,
+    observer::Observer::{Cie1931, Cie2015_10},
+    rgb::RgbSpace::SRGB,
+};
+
+let paint = Munsell::try_new("5BG5/8").unwrap();
+let vc = ViewConditions::average_surround(6.0);
+let cam_paint = Cie2015_10.ciecam16(&LED_B2, &paint, vc);
+let rgb_2015 = cam_paint
+    .rgb(SRGB, Some(CIE248_HOME_SCREEN))
+    .unwrap()
+    .compress();
+
+// Use a spectral representation of the Cie2015_10 RGB pixel, using the `Rgb`'s Light trait,
+// and calculate its XYZ tristimulus and RGB values for the CIE 1931 standard observer, the
+// observer
+// required for the sRGB color space.
+let xyz_1931 = Cie1931.xyz(&rgb_2015, None);
+let rgb_1931 = xyz_1931.rgb(SRGB).compress();
+let [r, g, b]: [u8; 3] = rgb_1931.into();
+//  (0, 113, 138)
 ```
 </details>
 

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -38,7 +38,11 @@ pub use crate::cam::cam16::CieCam16;
 mod cam02;
 pub use crate::cam::cam02::CieCam02;
 
-use crate::{observer::Observer, xyz::XYZ};
+use crate::{
+    observer::Observer,
+    rgb::{RgbSpace, WideRgb},
+    xyz::XYZ,
+};
 use nalgebra::{matrix, vector, SMatrix, Vector3};
 use std::f64::consts::PI;
 
@@ -51,7 +55,7 @@ pub struct CamJCh {
     /// Correlates of Lightness, Chroma, and hue-angle
     jch: Vector3<f64>,
 
-    /// Tristimulus values of the reference white beng use
+    /// Tristimulus values of the reference white being use
     xyzn: Vector3<f64>,
 
     /// Viewing Conditions
@@ -234,6 +238,19 @@ impl CamJCh {
             }
         };
         Ok(XYZ::from_vecs(xyz, self.observer))
+    }
+
+    pub fn rgb(
+        &self,
+        rgbspace: RgbSpace,
+        opt_viewconditions: Option<ViewConditions>,
+        cam: Cam,
+    ) -> Result<WideRgb, crate::Error> {
+        let viewconditions = opt_viewconditions.unwrap_or_default();
+        let observer = self.observer;
+        let xyzn = observer.xyz(&rgbspace.white(), None).set_illuminance(100.0);
+        let xyz = self.xyz(Some(xyzn), Some(viewconditions), cam)?;
+        Ok(xyz.rgb(rgbspace))
     }
 }
 

--- a/src/cam/cam02.rs
+++ b/src/cam/cam02.rs
@@ -125,7 +125,7 @@ impl CieCam02 {
     /// // Original CAM16 instance:
     /// let sample_xyz = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
     /// let white_xyz  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
-    /// let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
+    /// let vc = ViewConditions::new(40.0, 16.0, 0.69, 1.0, 1.0, None);
     /// let cam = CieCam02::from_xyz(sample_xyz, white_xyz, vc).unwrap();
     ///
     /// // Inverse under same conditions:
@@ -189,7 +189,7 @@ mod cam02_test {
 
         // Table 4, column 2, CIE 159:2004.
         // La = 20 cd/m2;
-        let vc = ViewConditions::new(18.0, 1.0, 1.0, 0.69, 20.0, None);
+        let vc = ViewConditions::new(20.0, 18.0, 0.69, 1.0, 1.0, None);
         let cam = CieCam02::from_xyz(xyz, xyzn, vc).unwrap();
         let jch = cam.jch_vec();
         let &[j, c, h] = jch.as_ref();
@@ -199,7 +199,7 @@ mod cam02_test {
 
         // Table 4, column 3, CIE 159:2004.
         // La = 200 cd/m2;
-        let vc = ViewConditions::new(18.0, 1.0, 1.0, 0.69, 200.0, None);
+        let vc = ViewConditions::new(200.0, 18.0, 0.69, 1.0, 1.0, None);
         let cam = CieCam02::from_xyz(xyz, xyzn, vc).unwrap();
         let jch = cam.jch_vec();
         let &[j, c, h] = jch.as_ref();

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -297,11 +297,13 @@ mod rgb_test {
         feature = "cie-illuminants"
     ))]
     fn rgb_match() {
-        use crate::cam::{ViewConditions, CIE248_HOME_SCREEN};
-        use crate::colorant::Munsell;
-        use crate::illuminant::LED_B2;
-        use crate::observer::Observer::{Cie1931, Cie2015_10};
-        use crate::rgb::RgbSpace::SRGB;
+        use crate::{
+            cam::{ViewConditions, CIE248_HOME_SCREEN},
+            colorant::Munsell,
+            illuminant::LED_B2,
+            observer::Observer::{Cie1931, Cie2015_10},
+            rgb::RgbSpace::SRGB,
+        };
 
         let paint = Munsell::try_new("5BG5/8").unwrap();
         let vc = ViewConditions::average_surround(6.0);
@@ -316,7 +318,6 @@ mod rgb_test {
         let xyz_1931 = Cie1931.xyz(&rgb_2015, None);
         let rgb_1931 = xyz_1931.rgb(SRGB).compress();
         let [r, g, b]: [u8; 3] = rgb_1931.into();
-        dbg!(r, g, b);
-        // let rgb_traditional = Cie1931.rgb()
+        assert!(r == 0 && g == 113 && b == 138);
     }
 }

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -32,7 +32,12 @@ use super::{CamJCh, CamTransforms, ViewConditions};
 
 use nalgebra::Vector3;
 
-use crate::{error::Error, observer::Observer, xyz::XYZ};
+use crate::{
+    error::Error,
+    observer::Observer,
+    rgb::{RgbSpace, WideRgb},
+    xyz::XYZ,
+};
 
 /// CIECAM16 Color Appearance Model
 ///
@@ -141,6 +146,15 @@ impl CieCam16 {
             .xyz(opt_xyzn, opt_viewconditions, super::Cam::CieCam16)
     }
 
+    pub fn rgb(
+        &self,
+        rgbspace: RgbSpace,
+        opt_viewconditions: Option<ViewConditions>,
+    ) -> Result<WideRgb, Error> {
+        self.0
+            .rgb(rgbspace, opt_viewconditions, super::Cam::CieCam16)
+    }
+
     /// Calculates the CIECAM16-UCS ΔE′ (prime) color difference between two colors.
     ///
     /// This method converts each color to its CAM16-UCS Ja′b′ coordinates and then computes the
@@ -211,7 +225,7 @@ mod cam16_test {
         // see section 7 CIE 248:2022
         let xyz = XYZ::new([60.70, 49.60, 10.29], Observer::Cie1931);
         let xyzn = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
-        let vc = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
+        let vc = ViewConditions::new(40.0, 16.0, 0.69, 1.0, 1.0, None);
         let cam = CieCam16::from_xyz(xyz, xyzn, vc).unwrap();
         let &[j, c, h] = cam.jch_vec().as_ref();
         //println!("J:\t{j:?}\nC:\t{c:?}\nh:\t{h:?}");
@@ -271,5 +285,38 @@ mod cam16_round_trip_tests {
             assert_abs_diff_eq!(y0, y1, epsilon = 1e-6);
             assert_abs_diff_eq!(z0, z1, epsilon = 1e-6);
         }
+    }
+}
+
+#[cfg(test)]
+mod rgb_test {
+    #[test]
+    #[cfg(all(
+        feature = "supplemental-observers",
+        feature = "munsell",
+        feature = "cie-illuminants"
+    ))]
+    fn rgb_match() {
+        use crate::cam::{ViewConditions, CIE248_HOME_SCREEN};
+        use crate::colorant::Munsell;
+        use crate::illuminant::LED_B2;
+        use crate::observer::Observer::{Cie1931, Cie2015_10};
+        use crate::rgb::RgbSpace::SRGB;
+
+        let paint = Munsell::try_new("5BG5/8").unwrap();
+        let vc = ViewConditions::average_surround(6.0);
+        let cam_paint = Cie2015_10.ciecam16(&LED_B2, &paint, vc);
+        let rgb_2015 = cam_paint
+            .rgb(SRGB, Some(CIE248_HOME_SCREEN))
+            .unwrap()
+            .compress();
+
+        // Use spectral representation of the Cie2015_10 RGB pixel
+        // to convert to CIE1931
+        let xyz_1931 = Cie1931.xyz(&rgb_2015, None);
+        let rgb_1931 = xyz_1931.rgb(SRGB).compress();
+        let [r, g, b]: [u8; 3] = rgb_1931.into();
+        dbg!(r, g, b);
+        // let rgb_traditional = Cie1931.rgb()
     }
 }

--- a/src/cam/viewconditions.rs
+++ b/src/cam/viewconditions.rs
@@ -26,6 +26,18 @@ pub struct ViewConditions {
 }
 
 impl ViewConditions {
+    /// Creates a new instance of `ViewConditions`.
+    ///
+    /// # Arguments
+    /// * `la` - Adaptation luminance in cd/m².
+    /// * `yb` - Relative background luminance, as a fraction of the white point’s Yn (cd/m²) value. Typically yb = 20, if Yn = 100.
+    /// * `c` - Impact of surround on chroma/contrast.
+    /// * `nc` - Chromatic induction factor.
+    /// * `f` - Surround factor, representing the degree of adaptation.
+    /// * `dopt` - Degree of adaptation, if omitted, formula 4.3 of CIE248:2022 is used.
+    ///
+    /// # Returns
+    /// A new instance of `ViewConditions`.
     pub const fn new(
         la: f64,
         yb: f64,
@@ -43,7 +55,23 @@ impl ViewConditions {
             dopt,
         }
     }
-
+    /// Creates a new `ViewConditions` instance with average surround settings,
+    /// as defined in CIE 248:2022.
+    ///
+    /// # Arguments
+    /// * `la` – Adaptation luminance in cd/m².
+    ///
+    /// # Returns
+    /// A `ViewConditions` configured for an average surround environment.
+    ///
+    /// # Notes
+    /// The average surround condition corresponds to a surround ratio greater than, as specified in
+    /// Annex B of CIE 248:2022. It is typically used in controlled environments such as color viewing
+    /// cabinets, where lighting is consistent and neutral.  This can also be used for general lighting
+    /// applications, looking at a color patch not lit by a spot light.
+    ///
+    /// This method sets `c = 0.69`, `nc = 1.0`, and `f = 1.0`, in line with CIE 248:2022
+    /// recommendations for average surround viewing conditions.
     pub const fn average_surround(la: f64) -> ViewConditions {
         ViewConditions {
             la,
@@ -55,6 +83,26 @@ impl ViewConditions {
         }
     }
 
+    /// Creates a new `ViewConditions` instance with dim surround settings,
+    /// as defined in CIE 248:2022.
+    ///
+    /// # Arguments
+    /// * `la` – Adaptation luminance in cd/m².
+    ///
+    /// # Returns
+    /// A `ViewConditions` configured for a dim surround environment.
+    ///
+    /// # Notes
+    /// The dim surround condition corresponds to a surround ratio between 0.0 and 0.2,
+    /// as described in Annex B of CIE 248:2022. It is typically used for viewing
+    /// self-luminous displays in home settings.
+    ///
+    /// For example, if a display emits 80 cd/m² (white luminance), and the background wall
+    /// is illuminated to about 30 lux—roughly 10 cd/m²—the surround ratio is 10 / 80 = 0.125,
+    /// which falls within the dim range.
+    ///
+    /// This method sets `c = 0.59`, `nc = 0.9`, and `f = 0.9`, following the dim surround
+    /// parameters specified by CIE 248:2022 for color appearance modeling.
     pub const fn dim_surround(la: f64) -> ViewConditions {
         ViewConditions {
             la,
@@ -66,6 +114,26 @@ impl ViewConditions {
         }
     }
 
+    /// Creates a new `ViewConditions` instance with dark surround settings,
+    /// as defined in CIE 248:2022.
+    ///
+    /// # Arguments
+    /// * `la` – Adaptation luminance in cd/m².
+    ///
+    /// # Returns
+    /// A `ViewConditions` configured for a dark surround environment.
+    ///
+    /// # Notes
+    /// The dark surround condition corresponds to a surround ratio approaching zero, as described in
+    /// Annex B of CIE 248:2022.  This setting is used for viewing projected or cinematic images in
+    /// darkened rooms where ambient luminance is minimal.
+    ///
+    /// For example, if the display luminance is 80 cd/m² and the room walls appear black, with a
+    /// luminance less than 1 cd/m² of luminance, the surround ratio would be around 0.0125.
+    ///
+    /// This method sets `c = 0.525`, `nc = 0.8`, and `f = 0.8`,
+    /// matching the parameters recommended by CIE 248:2022
+    /// for color appearance modeling in dark environments.
     pub const fn dark_surround(la: f64) -> ViewConditions {
         ViewConditions {
             la,
@@ -216,14 +284,7 @@ impl ViewConditions {
 
 impl Default for ViewConditions {
     fn default() -> Self {
-        Self {
-            yb: 20.0,
-            c: 0.69,
-            nc: 1.0,
-            f: 1.0,
-            la: 100.0,
-            dopt: None,
-        }
+        Self::average_surround(100.0)
     }
 }
 

--- a/src/cam/viewconditions.rs
+++ b/src/cam/viewconditions.rs
@@ -22,12 +22,22 @@ pub struct ViewConditions {
     /// La = Lw/5, with Lw: luminance of a perfect white object
     la: f64,
     nc: f64,
+
+    // The Y value of the “grey surround” immediately around the stimulus, expressed in the same scale as Yw.
     yb: f64,
+
     c: f64,
 }
 
 impl ViewConditions {
-    pub fn new(yb: f64, f: f64, nc: f64, c: f64, la: f64, dopt: Option<f64>) -> ViewConditions {
+    pub const fn new(
+        la: f64,
+        yb: f64,
+        c: f64,
+        nc: f64,
+        f: f64,
+        dopt: Option<f64>,
+    ) -> ViewConditions {
         ViewConditions {
             yb,
             f,
@@ -35,6 +45,39 @@ impl ViewConditions {
             c,
             la,
             dopt,
+        }
+    }
+
+    pub const fn average_surround(la: f64) -> ViewConditions {
+        ViewConditions {
+            la,
+            yb: 20.0,
+            c: 0.69,
+            nc: 1.0,
+            f: 1.0,
+            dopt: None,
+        }
+    }
+
+    pub const fn dim_surround(la: f64) -> ViewConditions {
+        ViewConditions {
+            la,
+            yb: 20.0,
+            c: 0.59,
+            nc: 0.9,
+            f: 0.9,
+            dopt: None,
+        }
+    }
+
+    pub const fn dark_surround(la: f64) -> ViewConditions {
+        ViewConditions {
+            la,
+            yb: 20.0,
+            c: 0.525,
+            nc: 0.8,
+            f: 0.8,
+            dopt: None,
         }
     }
 
@@ -53,7 +96,7 @@ impl ViewConditions {
         self.la
     }
 
-    ///  relative background luminance, as a fraction of the white point’s Y value  
+    ///  relative background luminance, as a fraction of the white point’s Yn (cd/m2) value  
     pub fn relative_background_luminance(&self) -> f64 {
         self.yb
     }
@@ -183,77 +226,25 @@ impl Default for ViewConditions {
 
 /// ViewConditions as used for TM30 and Color FIdelity Calculations
 /// (ANSI/TM-30-20-2020)
-pub const TM30VC: ViewConditions = ViewConditions {
-    yb: 20.0,
-    c: 0.69,
-    nc: 1.0,
-    f: 1.0,
-    la: 100.0,
-    dopt: Some(1.0),
-};
+pub const TM30VC: ViewConditions = ViewConditions::new(100.0, 20.0, 0.69, 1.0, 1.0, Some(1.0));
 
 /// Values according to Table 1, CIE 248:2022
 ///    
-/// 1) Surface colour evaluation in a color viewing cabinet
-///
-///   – Adopted white point: Viewing-cabinet white ⇒ Yₙ = 318.3 cd·m⁻²  
-///   – Adaptation luminance: L_A = 63.7 cd·m⁻²  
-///   – Surround: Average ⇒ (f = 1.0, c = 0.69, nc = 1.0)  
-///   – Surround ratio: S_R = 1 ⇒ background luminance Y_b = 1 × 318.3 = 318.3 cd·m⁻²
-///
-pub const CIE248_CABINET: ViewConditions = ViewConditions {
-    yb: 318.3,  // = 1 × 318.3
-    f: 1.0,     // “average” surround
-    nc: 1.0,    // “average” surround
-    c: 0.69,    // “average” surround
-    la: 63.7,   // adaptation luminance (cd·m⁻²)
-    dopt: None, // let the library compute D via CIE248:2022
-};
+pub const CIE248_CABINET: ViewConditions = ViewConditions::average_surround(
+    63.7, // adaptation luminance (cd·m⁻²) = 0.2 * Lw (perfect white object)
+);
 
 /// 2) Viewing a self-luminous display at home
-///
-///   – Adopted white point: between display white and ambient white ⇒ Yₙ = 80 cd·m⁻²  
-///   – Adaptation luminance: L_A = 16 cd·m⁻²  
-///   – Surround: Dim ⇒ (f = 0.9, c = 0.59, nc = 0.9)  
-///   – Surround ratio: S_R = 0.15 ⇒ Y_b = 0.15 × 80 = 12 cd·m⁻²
-///
-pub const CIE248_HOME_SCREEN: ViewConditions = ViewConditions {
-    yb: 12.0, // = 0.15 × 80
-    f: 0.9,   // “dim” surround
-    nc: 0.9,  // “dim” surround
-    c: 0.59,  // “dim” surround
-    la: 16.0, // adaptation luminance (cd·m⁻²)
-    dopt: None,
-};
+pub const CIE248_HOME_SCREEN: ViewConditions = ViewConditions::dim_surround(
+    16.0, // adaptation luminance (cd·m⁻²)
+);
 
 /// 3) Viewing projected images in a darkened room
-///
-///   – Adopted white point: between projector white and ambient white ⇒ Yₙ = 150 cd·m⁻²  
-///   – Adaptation luminance: L_A = 30 cd·m⁻²  
-///   – Surround: Dark ⇒ (f = 0.8, c = 0.525, nc = 0.8)  
-///   – Surround ratio: S_R = 0 ⇒ Y_b = 0 × 150 = 0 cd·m⁻²
-///
-pub const CIE248_PROJECTED_DARK: ViewConditions = ViewConditions {
-    yb: 0.0,  // = 0 × 150
-    f: 0.8,   // “dark” surround
-    nc: 0.8,  // “dark” surround
-    c: 0.525, // “dark” surround
-    la: 30.0, // adaptation luminance (cd·m⁻²)
-    dopt: None,
-};
+pub const CIE248_PROJECTED_DARK: ViewConditions = ViewConditions::dark_surround(
+    30.0, // adaptation luminance (cd·m⁻²)
+);
 
 /// 4) Viewing a self-luminous display under office illumination
-///
-///   – Adopted white point: between display white and office white ⇒ Yₙ = 80 cd·m⁻²  
-///   – Adaptation luminance: L_A = 16 cd·m⁻²  
-///   – Surround: Average ⇒ (f = 1.0, c = 0.69, nc = 1.0)  
-///   – Surround ratio: S_R = 2 ⇒ Y_b = 2 × 80 = 160 cd·m⁻²
-///
-pub const CIE248_OFFICE_SCREEN: ViewConditions = ViewConditions {
-    yb: 160.0, // = 2 × 80
-    f: 1.0,    // “average” surround
-    nc: 1.0,   // “average” surround
-    c: 0.69,   // “average” surround
-    la: 16.0,  // adaptation luminance (cd·m⁻²)
-    dopt: None,
-};
+pub const CIE248_OFFICE_SCREEN: ViewConditions = ViewConditions::average_surround(
+    16.0, // adaptation luminance (cd·m⁻²)
+);

--- a/src/cam/viewconditions.rs
+++ b/src/cam/viewconditions.rs
@@ -14,19 +14,15 @@ use super::{Cam, M16, MCAT02, MCAT02INV, MHPE};
 ///  
 /// The TM30 and Color Fidelity ViewConditions are provided as [`TM30VC`].
 pub struct ViewConditions {
-    dopt: Option<f64>,
-
-    f: f64,
-
     /// Adaptation Luminance, in cd/m2.
     /// La = Lw/5, with Lw: luminance of a perfect white object
     la: f64,
-    nc: f64,
-
     // The Y value of the “grey surround” immediately around the stimulus, expressed in the same scale as Yw.
     yb: f64,
-
     c: f64,
+    nc: f64,
+    f: f64,
+    dopt: Option<f64>,
 }
 
 impl ViewConditions {
@@ -78,6 +74,13 @@ impl ViewConditions {
             nc: 0.8,
             f: 0.8,
             dopt: None,
+        }
+    }
+
+    pub fn set_degree_of_adaptation(&self, d: f64) -> ViewConditions {
+        ViewConditions {
+            dopt: Some(d.clamp(0.0, 1.0)),
+            ..*self
         }
     }
 

--- a/src/colorant/tcs.rs
+++ b/src/colorant/tcs.rs
@@ -38,7 +38,7 @@ fn tcs_test() {
     use crate::observer::Observer::Cie1931;
     for (i, s) in TCS.iter().enumerate() {
         let xyz = Cie1931.xyz(&crate::illuminant::CieIlluminant::D65, Some(s));
-        let [r, g, b]: [u8; 3] = xyz.rgb(Some(crate::rgb::RgbSpace::SRGB)).clamp().into();
+        let [r, g, b]: [u8; 3] = xyz.rgb(crate::rgb::RgbSpace::SRGB).clamp().into();
         println!("{:2} ({r:3},{g:3},{b:3})", i + 1);
     }
 }

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -124,7 +124,7 @@ impl CieLab {
     pub fn set_white_luminance(mut self, luminance: f64) -> CieLab {
         // Adjust the reference white to the new luminance
         let scale = luminance / self.xyzn.y;
-        self.xyzn = self.xyzn * scale;
+        self.xyzn *= scale;
         self
     }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -96,6 +96,38 @@ impl CieLab {
         }
     }
 
+    pub fn xyz(&self) -> XYZ {
+        // Convert back to XYZ for any further processing
+        let xyz = xyz_from_cielab(self.lab, self.xyzn);
+        XYZ::from_vecs(xyz, self.observer)
+    }
+
+    pub fn xyzn(&self) -> Vector3<f64> {
+        // Return the reference white XYZ tristimulus value
+        self.xyzn
+    }
+
+    /// Sets the reference white luminance for this CIE L*a*b* color, in units of cd/m².
+    ///
+    /// # Arguments
+    /// * `luminance` - The desired luminance level for the reference white.
+    /// # Returns
+    /// A new `CieLab` instance with the adjusted luminance.     
+    ///
+    /// This adjusts the reference white to the specified illuminance level.
+    ///
+    /// # Notes
+    /// - This does not change the L\*a\*b\* values directly; it modifies the reference white
+    ///   to scale the white reference luminance.
+    /// - Typically the value is set to 100 for normalized white luminance, but more advanced models,
+    ///   such as CIECAM16, may use different luminance levels for perceptual accuracy.
+    pub fn set_white_luminance(mut self, luminance: f64) -> CieLab {
+        // Adjust the reference white to the new luminance
+        let scale = luminance / self.xyzn.y;
+        self.xyzn = self.xyzn * scale;
+        self
+    }
+
     /// Computes the Euclidean ΔE*ab color difference between two CIE L\*a\*b\* colors.
     ///
     /// This function measures the straight-line distance in L\*a\*b\* space:
@@ -192,29 +224,71 @@ impl AsRef<[f64; 3]> for CieLab {
     }
 }
 
-const DELTA: f64 = 24f64 / 116f64;
-const DELTA_POW2: f64 = DELTA * DELTA;
-const DELTA_POW3: f64 = DELTA_POW2 * DELTA;
-const LABPOW: f64 = 1f64 / 3f64;
-const LABC1: f64 = 1f64 / (3f64 * DELTA_POW2);
-const LABC2: f64 = 4f64 / 29f64;
-
-fn lab_f(t: f64) -> f64 {
-    if t > DELTA_POW3 {
-        t.powf(LABPOW)
-    } else {
-        LABC1 * t + LABC2
-    }
-}
-
 fn lab(xyz: Vector3<f64>, xyzn: Vector3<f64>) -> Vector3<f64> {
+    const DELTA: f64 = 24f64 / 116f64;
+    const DELTA_POW2: f64 = DELTA * DELTA;
+    const DELTA_POW3: f64 = DELTA_POW2 * DELTA;
+    const LABPOW: f64 = 1f64 / 3f64;
+    const LABC1: f64 = 1f64 / (3f64 * DELTA_POW2);
+    const LABC2: f64 = 4f64 / 29f64;
+
     let &[x, y, z] = xyz.as_ref();
     let &[xn, yn, zn] = xyzn.as_ref();
+
+    // helper function
+    fn lab_f(t: f64) -> f64 {
+        if t > DELTA_POW3 {
+            t.powf(LABPOW)
+        } else {
+            LABC1 * t + LABC2
+        }
+    }
+
     Vector3::new(
         116f64 * lab_f(y / yn) - 16f64,
         500f64 * (lab_f(x / xn) - lab_f(y / yn)),
         200f64 * (lab_f(y / yn) - lab_f(z / zn)),
     )
+}
+
+/// CIELAB → CIEXYZ (D50, D65 or any other reference white passed in `xyzn`)
+///
+/// * `lab`  – L*, a*, b* vector  
+/// * `xyzn` – reference-white Xn, Yn, Zn (must be in the **same scale** as the XYZ values
+///            you want out – e.g. Yn = 100 for 0-to-100 “percent” data or Yn = 1.0 for
+///            ICC/PCS-scaled values)
+///
+/// Returns XYZ in the same scaling as `xyzn`.
+pub fn xyz_from_cielab(lab: Vector3<f64>, xyzn: Vector3<f64>) -> Vector3<f64> {
+    // CIE constants
+    const EPS: f64 = 216.0 / 24_389.0; // δ³  (≈ 0.008856)
+    const KAPPA: f64 = 24_389.0 / 27.0; // κ  (≈ 903.296 3)
+
+    let &[l, a, b] = lab.as_ref();
+    let &[xn, yn, zn] = xyzn.as_ref();
+
+    // 1. Recover the “f” terms
+    let fy = (l + 16.0) / 116.0;
+    let fx = a / 500.0 + fy;
+    let fz = fy - b / 200.0;
+
+    // 2. Helper to invert the piece-wise f(t) used in the forward transform
+    fn f_inv(f: f64) -> f64 {
+        let f3 = f * f * f;
+        if f3 > EPS {
+            f3
+        } else {
+            (116.0 * f - 16.0) / KAPPA
+        }
+    }
+
+    // 3. Relative XYZ (scaled by the white point)
+    let xr = f_inv(fx);
+    let yr = f_inv(fy);
+    let zr = f_inv(fz);
+
+    // 4. Absolute XYZ
+    Vector3::new(xr * xn, yr * yn, zr * zn)
 }
 
 /// Compute the CIEDE2000 ΔE between two CIE L*a*b* triples.
@@ -295,10 +369,19 @@ fn delta_e_ciede2000(lab1: Vector3<f64>, lab2: Vector3<f64>) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::observer::Observer::Cie1931;
-    use crate::prelude::*;
+    use crate::{lab::CieLab, observer::Observer::Cie1931, xyz::XYZ};
     use approx::assert_abs_diff_eq;
     use nalgebra::vector;
+
+    #[test]
+    fn lab_roundtrip_test() {
+        let xyz_values = [36.0, 70.0, 12.0];
+        let xyz = XYZ::new(xyz_values, Cie1931);
+        let white = Cie1931.xyz_d65(); // Reference white point (D65 illuminant)
+        let lab = CieLab::from_xyz(xyz, white).unwrap();
+        let xyz_back = lab.xyz();
+        assert_abs_diff_eq!(xyz, xyz_back, epsilon = 1e-10);
+    }
 
     #[test]
     fn delta_e_ciede2000_example1() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,26 +22,26 @@ or add this line to the dependencies in your Cargo.toml file:
 This example calculates the XYZ tristimulus values of the D65 illuminant for both the CIE 1931 2º standard observer and the CIE 2015 10º observer.
 
 ```
-    use colorimetry::illuminant::D65;
+use colorimetry::illuminant::D65;
 #   use approx::assert_abs_diff_eq as check;
 
-    // D65 Tristimulus values, using the CIE1931 standard observer by default
-    let xyz_d65 = D65.xyz(None).set_illuminance(100.0);
+// D65 Tristimulus values, using the CIE1931 standard observer by default
+let xyz_d65 = D65.xyz(None).set_illuminance(100.0);
 
-    let [x, y, z] = xyz_d65.values();
-    // [95.04, 100.0, 108.86]
+let [x, y, z] = xyz_d65.values();
+// [95.04, 100.0, 108.86]
 #   check!([x, y, z].as_ref(), [95.04, 100.0, 108.86].as_ref(),  epsilon = 5E-3);
 
 # #[cfg(feature = "supplemental-observers")]
 # {
-    // D65 Tristimulus values using the CIE2015 10º observer
-    // This requires the `supplemental-observers` feature (enabled by default)
-    use colorimetry::observer::Observer::Cie2015_10;
-    let xyz_d65_10 = D65
-        .xyz(Some(Cie2015_10)).set_illuminance(100.0);
+// D65 Tristimulus values using the CIE2015 10º observer
+// This requires the `supplemental-observers` feature (enabled by default)
+use colorimetry::observer::Observer::Cie2015_10;
+let xyz_d65_10 = D65
+    .xyz(Some(Cie2015_10)).set_illuminance(100.0);
 
-    let [x_10, y_10, z_10] = xyz_d65_10.values();
-    //[94.72, 100.0, 107.143]
+let [x_10, y_10, z_10] = xyz_d65_10.values();
+//[94.72, 100.0, 107.143]
 #   check!([x_10, y_10, z_10].as_ref(), [94.72, 100.0, 107.143].as_ref(), epsilon = 5E-3);
 # }
 ```
@@ -58,16 +58,16 @@ locus, often referred to as the tint.
 
 ```
 # #[cfg(feature="cie-illuminants")]
-    use colorimetry::illuminant::A;
+use colorimetry::illuminant::A;
 #   use approx::assert_abs_diff_eq as check;
 
-    // Calculate CCT and Duv for the A illuminant
-    // Requires `cct`, and `cie-illuminants` features
+// Calculate CCT and Duv for the A illuminant
+// Requires `cct`, and `cie-illuminants` features
 # #[cfg(all(feature="cct", feature="cie-illuminants"))]
-    let [cct, duv] = A.cct().unwrap().values();
+let [cct, duv] = A.cct().unwrap().values();
 # #[cfg(all(feature="cct", feature="cie-illuminants"))]
 #    check!([cct, duv].as_ref(), [2855.4977, 0.0].as_ref(),  epsilon = 5E-4);
-    // [2855.4977, 0.0]
+// [2855.4977, 0.0]
 ```
 </details>
 
@@ -83,16 +83,16 @@ Below is an example calculation of the general Color Fidelity Index for the CIE 
 
 ```
 # #[cfg(feature = "cie-illuminants")]
-    use colorimetry::illuminant::F2;
+use colorimetry::illuminant::F2;
 #   use approx::assert_abs_diff_eq as check;
 
 # #[cfg(all(feature = "cfi", feature = "cie-illuminants"))]
 # {
-    // Calculate the Color Fidelity Index of the CIE F2 standard illuminant
-    // Requires `cfi`, and `cie-illuminants` features
-    let cf_f2 = F2.cfi().unwrap();
-    let cf = cf_f2.general_color_fidelity_index();
-    // 70.3
+// Calculate the Color Fidelity Index of the CIE F2 standard illuminant
+// Requires `cfi`, and `cie-illuminants` features
+let cf_f2 = F2.cfi().unwrap();
+let cf = cf_f2.general_color_fidelity_index();
+// 70.3
 #   check!(cf, 70.3,  epsilon = 1E-1);
 # }
 ```
@@ -108,16 +108,16 @@ physically realizable colors. Due to its shape, it is sometimes informally refer
 Below, we compute the chromaticity coordinates that define the spectral locus.
 
 ```
-    use colorimetry::observer::Observer::Cie1931;
-    let mut locus = Vec::new();
-    let wavelength_range = Cie1931.spectral_locus_wavelength_range();
-    for wavelength in wavelength_range {
-        // unwrap OK because nm is in range
-        let xyz = Cie1931.xyz_at_wavelength(wavelength).unwrap();
-        let chromaticity = xyz.chromaticity();
-        locus.push([wavelength as f64, chromaticity.x(), chromaticity.y()]);
-    }
-    println!("{locus:?}");
+use colorimetry::observer::Observer::Cie1931;
+let mut locus = Vec::new();
+let wavelength_range = Cie1931.spectral_locus_wavelength_range();
+for wavelength in wavelength_range {
+    // unwrap OK because nm is in range
+    let xyz = Cie1931.xyz_at_wavelength(wavelength).unwrap();
+    let chromaticity = xyz.chromaticity();
+    locus.push([wavelength as f64, chromaticity.x(), chromaticity.y()]);
+}
+println!("{locus:?}");
 ```
 </details>
 
@@ -129,46 +129,46 @@ Here, we compute transformation matrices for the `DisplayP3` color space using b
 
 ```
 #   use approx::assert_abs_diff_eq as check;
-    use colorimetry::observer::Observer;
-    use colorimetry::rgb::RgbSpace::DisplayP3;
+use colorimetry::observer::Observer;
+use colorimetry::rgb::RgbSpace::DisplayP3;
 
-    let xyz2rgb_31 = Observer::Cie1931.xyz2rgb(DisplayP3);
+let xyz2rgb_31 = Observer::Cie1931.xyz2rgb(DisplayP3);
 #   let want31 = nalgebra::Matrix3::new(
 #         2.4933, -0.9313, -0.4027,
 #        -0.8298,  1.7629,  0.0236,
 #         0.0355, -0.076,   0.9574
 #   );
 #   check!(xyz2rgb_31, want31, epsilon=5E-4);
-        //  2.4933, -0.9313, -0.4027,
-        // -0.8298,  1.7629,  0.0236,
-        //  0.0355, -0.076,   0.9574
+//  2.4933, -0.9313, -0.4027,
+// -0.8298,  1.7629,  0.0236,
+//  0.0355, -0.076,   0.9574
 
-    let rgb2xyz_31 = Observer::Cie1931.rgb2xyz(DisplayP3);
+let rgb2xyz_31 = Observer::Cie1931.rgb2xyz(DisplayP3);
 #   let want31inv = nalgebra::Matrix3::new(
 #       0.4866, 0.2656, 0.1981,
 #       0.2291, 0.6917, 0.0792,
 #       0.0001, 0.0451, 1.0433,
 #   );
 #   check!(rgb2xyz_31, want31inv, epsilon=5E-4);
-        // 0.4866, 0.2656, 0.1981,
-        // 0.2291, 0.6917, 0.0792,
-        // 0.0001, 0.0451, 1.0433,
+// 0.4866, 0.2656, 0.1981,
+// 0.2291, 0.6917, 0.0792,
+// 0.0001, 0.0451, 1.0433,
 
 #   #[cfg(feature = "supplemental-observers")]
 #   {
-    // requires `supplemental-observers`
-    use colorimetry::observer::Observer::Cie2015;
+// requires `supplemental-observers`
+use colorimetry::observer::Observer::Cie2015;
 
-    let xyz2rgb_15 = Cie2015.xyz2rgb(DisplayP3);
+let xyz2rgb_15 = Cie2015.xyz2rgb(DisplayP3);
 #   let want15 = nalgebra::Matrix3::new(
 #       2.5258,  -1.0009, -0.3649,
 #      -0.9006,   1.8546, -0.0011,
 #       0.0279,  -0.0574,  0.95874
 #   );
 #   check!(xyz2rgb_15, want15, epsilon=5E-4);
-        //  2.5258,  -1.0009, -0.3649,
-        // -0.9006,   1.8546, -0.0011,
-        //  0.0279,  -0.0574,  0.95874
+//  2.5258,  -1.0009, -0.3649,
+// -0.9006,   1.8546, -0.0011,
+//  0.0279,  -0.0574,  0.95874
 #    }
 ```
 </details>
@@ -186,21 +186,21 @@ In practical terms, a ΔE of 3 is considered a close match—just at the thresho
 # #[cfg(all(feature= "cri", feature = "supplemental-observers", feature = "munsell"))]
 # {
 #    use approx::assert_abs_diff_eq as check;
-    // requires `cri`, `supplemental-observers`, and `munsell` features
-    use colorimetry::observer::Observer::Cie2015_10;
-    use colorimetry::colorant::{MunsellCollection, TCS};
+// requires `cri`, `supplemental-observers`, and `munsell` features
+use colorimetry::observer::Observer::Cie2015_10;
+use colorimetry::colorant::{MunsellCollection, TCS};
 
-    let cri_r9 = &TCS[8];
-    let (key, delta_e) = MunsellCollection::match_ciecam16(
-        cri_r9,
-        None,
-        None,
-        Some(Cie2015_10),
-    )
-    .unwrap();
+let cri_r9 = &TCS[8];
+let (key, delta_e) = MunsellCollection::match_ciecam16(
+    cri_r9,
+    None,
+    None,
+    Some(Cie2015_10),
+)
+.unwrap();
 #   assert_eq!(key, "5R4/14");
 #   check!(delta_e, 3.0, epsilon = 5e-2);
-    // ("5R4/14", 3.0)
+// ("5R4/14", 3.0)
 # }
 ```
 </details>
@@ -208,18 +208,47 @@ In practical terms, a ΔE of 3 is considered a close match—just at the thresho
 <details>
 <summary><strong>Match a paint color to a <i>sRGB</i> display value under realistic viewing conditions</strong></summary>
 
-This example matches the Munsell paint chip “7.5 BG 7/8”—a light teal—to its nearest <i>sRGB</i>
-equivalent value under conditions that mimic real-world viewing. Instead of the traditional <i>CIE
-1931 2°</i> observer, we use the <i>CIE 2015 10° observer</i>, which better represents how paint
-colours appear at on a wall. We'll assume the paint is illuminated with the warm-white <i>LED_B2</i>
-standard illuminant (≈ 3000 K). Taken together, the display color matches what you’d see on
-a freshly painted wall.
+This example matches the Munsell paint chip <i>5 BG 5/8</i>—a teal/blue-green color—
+to its nearest <i>sRGB</i>
+<span style="display: inline-block; width: 1em; height: 1em; background-color: rgb(0, 113, 138);
+border-radius: 50%; vertical-align: middle; border: 1px solid #000;"></span>
+<span>rgb(0, 113, 138)</span>
+equivalent, mimicking real-world viewing conditions.
+
+Instead of the traditional <i>CIE 1931 2°</i> observer, this match uses the <i>CIE 2015 10° observer</i>,
+which more accurately reflects how paint colors appear on walls. The illumination is based on the warm-white
+<i>LED_B2</i> standard illuminant (≈ 3000 K). Together, these adjustments help the display color reflect
+what you'd actually see on a freshly painted surface.
 
 ```
 # #[cfg(all(feature = "supplemental-observers", feature = "munsell", feature = "cie-illuminants"))]
 # {
-#    use approx::assert_abs_diff_eq as check;
-    // requires `supplemental-observers`, and `munsell` features
+// requires `supplemental-observers`, and `munsell` features
+use colorimetry::{
+    cam::{ViewConditions, CIE248_HOME_SCREEN},
+    colorant::Munsell,
+    illuminant::LED_B2,
+    observer::Observer::{Cie1931, Cie2015_10},
+    rgb::RgbSpace::SRGB,
+};
+
+let paint = Munsell::try_new("5BG5/8").unwrap();
+let vc = ViewConditions::average_surround(6.0);
+let cam_paint = Cie2015_10.ciecam16(&LED_B2, &paint, vc);
+let rgb_2015 = cam_paint
+    .rgb(SRGB, Some(CIE248_HOME_SCREEN))
+    .unwrap()
+    .compress();
+
+// Use a spectral representation of the Cie2015_10 RGB pixel, using the `Rgb`'s Light trait,
+// and calculate its XYZ tristimulus and RGB values for the CIE 1931 standard observer, the
+// observer
+// required for the sRGB color space.
+let xyz_1931 = Cie1931.xyz(&rgb_2015, None);
+let rgb_1931 = xyz_1931.rgb(SRGB).compress();
+let [r, g, b]: [u8; 3] = rgb_1931.into();
+//  (0, 113, 138)
+#   assert!(r == 0 && g == 113 && b == 138);
 # }
 ```
 </details>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,25 @@ In practical terms, a ΔE of 3 is considered a close match—just at the thresho
 ```
 </details>
 
+<details>
+<summary><strong>Match a paint color to a <i>sRGB</i> display value under realistic viewing conditions</strong></summary>
+
+This example matches the Munsell paint chip “7.5 BG 7/8”—a light teal—to its nearest <i>sRGB</i>
+equivalent value under conditions that mimic real-world viewing. Instead of the traditional <i>CIE
+1931 2°</i> observer, we use the <i>CIE 2015 10° observer</i>, which better represents how paint
+colours appear at on a wall. We'll assume the paint is illuminated with the warm-white <i>LED_B2</i>
+standard illuminant (≈ 3000 K). Taken together, the display color matches what you’d see on
+a freshly painted wall.
+
+```
+# #[cfg(all(feature = "supplemental-observers", feature = "munsell", feature = "cie-illuminants"))]
+# {
+#    use approx::assert_abs_diff_eq as check;
+    // requires `supplemental-observers`, and `munsell` features
+# }
+```
+</details>
+
 # Features
 
 - [`Spectrum`] Standard fixed-grid spectral representation over a wavelength range from 380 to 780 nanometers, with 1-nanometer intervals.

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -193,7 +193,7 @@ impl Observer {
     ///
     /// # Arguments
     /// * `light` - A reference to an object implementing the [Light] trait, such as [`CieIlluminant`].
-    /// * `filter` - A reference to an object implementing the [Filter] trait, such as [`Colorant`].
+    /// * `filter` - A reference to an object implementing the [Filter] trait, such as `Colorant`.
     ///
     /// # Returns
     /// * `CieLab` - The computed CIELAB color representation for the light and filter combination.

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -215,26 +215,43 @@ impl Observer {
         self.lab(&crate::illuminant::D50, filter)
     }
 
+    /// Calculates the CIECAM16 color appearance model values for a light source and filter combination.
+    /// This method is used to compute the color appearance of a light source
+    /// when filtered by a colorant or filter, using the CIECAM16 model.
+    /// It returns the CIECAM16 values normalized to a white reference luminance of 100.0.
+    /// # Arguments
+    /// * `light` - A reference to an object implementing the [Light] trait, such as [`CieIlluminant`].
+    /// * `filter` - A reference to an object implementing the [Filter] trait, such as `Colorant`.
+    /// * `vc` - The view conditions to use for the CIECAM16 calculation.
+    /// # Returns
+    /// * `CieCam16` - The computed CIECAM16 color appearance model representation for the light and filter combination.
     pub fn ciecam16(&self, light: &dyn Light, filter: &dyn Filter, vc: ViewConditions) -> CieCam16 {
         let [xyz, xyzn] = self.xyz_and_xyzn(light, filter);
         // unwrap OK as we are using only one observer (self) here
         CieCam16::from_xyz(xyz, xyzn, vc).unwrap()
     }
 
+    /// Calculates the CIECAM02 color appearance model values for a light source and filter combination.
+    /// This method is used to compute the color appearance of a light source
+    /// when filtered by a colorant or filter, using the CIECAM02 model.
+    /// It returns the CIECAM02 values normalized to a white reference luminance of 100.0.
+    /// # Arguments
+    /// * `light` - A reference to an object implementing the [Light] trait, such as [`CieIlluminant`].         
+    /// * `filter` - A reference to an object implementing the [Filter] trait, such as `Colorant`.
+    /// * `vc` - The view conditions to use for the CIECAM02 calculation.
+    /// # Returns
+    /// * `CieCam02` - The computed CIECAM02 color appearance model representation for the light and filter combination.
     pub fn ciecam02(&self, light: &dyn Light, filter: &dyn Filter, vc: ViewConditions) -> CieCam02 {
         let [xyz, xyzn] = self.xyz_and_xyzn(light, filter);
         // unwrap OK as we are using only one observer (self) here
         CieCam02::from_xyz(xyz, xyzn, vc).unwrap()
     }
 
-    /**
-        Calculates Tristimulus valus, in form of an [XYZ] object of a general spectrum.
-        If a reference white is given (rhs), it will copy its tristimulus value, and the spectrum
-        is interpreted as a stimulus, being a combination of an illuminant with a colorant.
-        If no reference white is given, the spectrum is interpreted as an illuminant.
-        This method produces the raw XYZ data, not normalized to 100.0
-
-    */
+    /// Calculates Tristimulus valus, in form of an [XYZ] object of a general spectrum.
+    /// If a reference white is given (rhs), it will copy its tristimulus value, and the spectrum
+    /// is interpreted as a stimulus, being a combination of an illuminant with a colorant.
+    /// If no reference white is given, the spectrum is interpreted as an illuminant.
+    /// This method produces the raw XYZ data, not normalized to 100.0
     pub fn xyz_from_spectrum(&self, spectrum: &Spectrum) -> XYZ {
         let xyz = self.data().data * spectrum.0 * self.data().lumconst;
         XYZ::from_vecs(xyz, self.data().tag)
@@ -336,9 +353,9 @@ impl Observer {
         self.rgb2xyz(rgbspace).try_inverse().unwrap()
     }
 
-    pub fn rgb(&self, rgbspace: RgbSpace) -> Matrix3<f64> {
-        self.rgb2xyz(rgbspace)
-    }
+    //  pub fn rgb(&self, rgbspace: RgbSpace) -> Matrix3<f64> {
+    //      self.rgb2xyz(rgbspace)
+    //  }
 
     /// Returns the wavelength range (in nanometer) for the _horse shoe_,
     /// the boundary of the area of all physical colors in a chromiticity diagram,
@@ -512,16 +529,15 @@ mod obs_test {
     }
 
     #[test]
-    // Data from http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
-    // Lindbloom's values are reproduced with an accuracy of 3E-4, which is
-    // a small, but significant difference.  This difference is caused by a difference in the display's white point,
-    // due to wavelength domain differences.  Here we use a domain
-    // from 380 to 780 with a step of 1 nanometer for the spectra, and in
-    // specific for the color matching functions, as recommended by
-    // CIE15:2004, and the color matching functions provided by the CIE in
-    // their online dataset section. The spectra for the primaries are chosen to match the RGB primary values as given by the Color Space specifications.
-    // The white point uses the standard's spectral distribution, as provided by the CIE, clipped to a domain from 380 to 780 nanometer.
-    // See `colorimetry::data::D65`.
+    // Data from http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html Lindbloom's values
+    // are reproduced with an accuracy of 3E-4, which is a small, but significant difference.  This
+    // difference is caused by a difference in the display's white point, due to wavelength domain
+    // differences.  Here we use a domain from 380 to 780 with a step of 1 nanometer for the
+    // spectra, and in specific for the color matching functions, as recommended by CIE15:2004, and
+    // the color matching functions provided by the CIE in their online dataset section. The spectra
+    // for the primaries are chosen to match the RGB primary values as given by the Color Space
+    // specifications.  The white point uses the standard's spectral distribution, as provided by
+    // the CIE, clipped to a domain from 380 to 780 nanometer.  See `colorimetry::data::D65`.
     fn test_rgb2xyz_cie1931() {
         let want = nalgebra::Matrix3::new(
             0.4124564, 0.3575761, 0.1804375, 0.2126729, 0.7151522, 0.0721750, 0.0193339, 0.1191920,

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -296,8 +296,7 @@ impl XYZ {
     /// - `WideRgb::compress()`
     ///
     /// These methods will change the color which will be less saturated, and less bright as the orignial color.
-    pub fn rgb(&self, space: Option<RgbSpace>) -> WideRgb {
-        let space = space.unwrap_or_default();
+    pub fn rgb(&self, space: RgbSpace) -> WideRgb {
         let xyz = self.xyz;
         let d = xyz.map(|v| v / 100.0); // normalize to 1.0
         let data = self.observer.xyz2rgb(space) * d;
@@ -400,11 +399,12 @@ mod xyz_test {
 
     #[test]
     fn test_rgb_roundtrip() {
+        use crate::rgb::RgbSpace::SRGB;
         let rgb_blue = WideRgb::new(0.0, 0.0, 1.0, Some(Observer::Cie1931), Some(RgbSpace::SRGB));
         let xyz_blue = rgb_blue.xyz();
         let xy_blue = xyz_blue.chromaticity().to_array();
         assert_ulps_eq!(xy_blue.as_ref(), [0.15, 0.06].as_ref(), epsilon = 1E-5);
-        let rgbb = xyz_blue.rgb(None);
+        let rgbb = xyz_blue.rgb(SRGB);
         assert_ulps_eq!(rgbb, rgb_blue);
     }
 


### PR DESCRIPTION
The example illustrates the spectral colorimetry capabilities of the library. It describes how to use the CIECAM16 model in combination with the CIE 2015 10 ° observer to match a real-world paint color, painted on a wall, with a 3000K LED illuminant, to an RGB color, when viewed on an sRGB display.

Also adding convenience functions such as `CieCam16::rgb` and simplifying the `ViewConditions` API to make it easier to use these. In particular, `ViewConditions::average_surround` and its siblings `dim_surround` and `dark_surround` make it much easier to experiment with these.