### PR TITLE
Make public enums that can be expanded `#[non_exhaustive]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Replaced all instances of `&RgbSpace` in the API with `RgbSpace`, as both were used inconsistently.
 - Updated inline code comments for clarity in color conversion routines and view‐condition constructors.
 - Refined README section layout and wording to better guide users through the new spectral examples.
+- Mark all enums that add variants when cargo features are enabled as `#[non_exhaustive]`.
+  This includes `Observer` and `CieIlluminant`.
+- Mark all enums that might get new variants in future non-API breaking releases as
+  `#[non_exhaustive]`. This includes `RgbSpace`, `Cam` and `Error`.
 
 ### Removed
 - Various normal distribution (gaussian) helper functions, now all collected as methods of the `Gaussian` struct.

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -77,6 +77,7 @@ pub struct ReferenceValues {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Cam {
     CieCam02,
     CieCam16,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 #[derive(thiserror::Error, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     #[error("{name} should be within in range from {low} to {high}")]
     OutOfRange { name: String, low: f64, high: f64 },

--- a/src/illuminant/cie_illuminant.rs
+++ b/src/illuminant/cie_illuminant.rs
@@ -10,6 +10,7 @@ macro_rules! std_illuminants {
         #[allow(non_camel_case_types)]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
         #[derive(Clone, Copy, Debug, strum_macros::Display, strum_macros::EnumIter)]
+        #[non_exhaustive]
         pub enum CieIlluminant  {
                 $($val,)*
         }
@@ -51,6 +52,7 @@ macro_rules! std_illuminants {
         #[allow(non_camel_case_types)]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
         #[derive(Clone, Debug, Copy, strum_macros::Display, strum_macros::EnumIter)]
+        #[non_exhaustive]
         pub enum CieIlluminant  {
                 $($val,)*
                 $($cieval,)*

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -122,6 +122,7 @@ impl ObserverData {
 #[cfg(not(feature = "supplemental-observers"))]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Debug, EnumIter)]
+#[non_exhaustive]
 pub enum Observer {
     #[default]
     Cie1931,
@@ -130,6 +131,7 @@ pub enum Observer {
 #[cfg(feature = "supplemental-observers")]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, Debug, EnumIter)]
+#[non_exhaustive]
 pub enum Observer {
     #[default]
     Cie1931,

--- a/src/rgb/rgbspace.rs
+++ b/src/rgb/rgbspace.rs
@@ -15,12 +15,11 @@ const D: f64 = 0.0005620; // Desaturation ratio
 const D65X: f64 = 0.312_738;
 const D65Y: f64 = 0.329_052;
 
+/// A Light Weight tag, representing an RGB color space.
+/// Used for example in the RGB value set, to identify the color space being used.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, EnumIter)]
-/**
-A Light Weight tag, representing an RGB color space.
-Used for example in the RGB value set, to identify the color space being used.
- */
+#[non_exhaustive]
 pub enum RgbSpace {
     #[default]
     SRGB,


### PR DESCRIPTION
Currently (before this PR), I could write a library that depend on `colorimetry` with all features disabled. I could then write code like this in my library:
```rust
match some_observer {
    Observer::Cie1931 => (),
}
```
The above would compile and be fully correct. However, if someone depend on my library, and they also end up depending on `colorimetry` somewhere else in their dependency tree, and that dependency enables the `supplemental-obeservers` feature. Then suddenly my library fails to compile with:
```
error[E0004]: non-exhaustive patterns: `Observer::Cie1964`, `Observer::Cie2015` and `Observer::Cie2015_10` not covered
```
That is because adding variants to enums is a breaking change unless the enum in `#[non_exhuastive]`. [Cargo features must be additive only and not API breaking](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification).

By adding `#[non_exhaustive]` we tell the library user that variants might be added to this enum in the future, or by enabling features etc.

I also added the `#[non_exhaustive]` property to some enums that are not conditionally adding variants based on cargo features. Because these enums felt like they could very well be expanded in the future. And without this tag doing so would require us to bump the version in an API breaking manner according to semver. While we are in a `0.0.x` phase this is a bit special of course, but this is preparing for the future. A good example is the `Error` enum. Say this library is released as `1.0.0` and then in we want to add a simple new function. But the function require a new error case. We could then not add this error case variant without bumping the version all the way to `2.0.0`, which would be very unfortunate for such a small feature addition.