### PR TITLE
Add `WideRgb::to_rgb` method for trying to convert without changing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add standard CIECAM viewing conditions as recommended by CIE248 as constants.
 - _Spectral RGB matching example_ to convert spectral reflectance into sRGB values using the CIE 2015 10° observer. 
 - New helper functions in the `cam` module (and submodules `cam02`, `cam16`, `viewconditions`) for spectral color appearance calculations and surround presets.
-- A comprehensive spectral _color management example_ in `README.md`, demonstrating matching the Munsell paint chip <i>5 BG 5/8</i> to its sRGB equivalent (LED_B2 illuminant, CIE 2015 10° observer).  [oai_citation:3‡github.com](https://github.com/harbik/colorimetry/pull/92/files)  
+- A comprehensive spectral _color management example_ in `README.md`, demonstrating matching the Munsell paint chip <i>5 BG 5/8</i> to its sRGB equivalent (LED_B2 illuminant, CIE 2015 10° observer).  [oai_citation:3‡github.com](https://github.com/harbik/colorimetry/pull/92/files)
+- Add `WideRgb::to_rgb` that returns an `Rgb` instance with the same channel values, if the wide
+  RGB was not out-of-gamut.
+- Add `WideRgb::is_in_gamut` to check if the RGB values are within the RGB gamut.
 
 ### Changed
 - Refactored `physics.rs` with the planck functions and LED functions now moved to the `Illuminant` module,

--- a/src/rgb/widergb.rs
+++ b/src/rgb/widergb.rs
@@ -128,6 +128,50 @@ impl WideRgb {
         }
     }
 
+    /// Returns whether or not this Wide RGB instance is within the RGB gamut or not.
+    ///
+    /// Being in gamut means all color channel values are in the range [0.0, 1.0].
+    ///
+    /// ```rust
+    /// # use colorimetry::rgb::WideRgb;
+    ///
+    /// let in_gamut = WideRgb::new(1.0, 0.2, 0.8, None, None);
+    /// assert!(in_gamut.is_in_gamut());
+    ///
+    /// let out_of_gamut = WideRgb::new(1.2, -0.5, 0.8, None, None);
+    /// assert!(!out_of_gamut.is_in_gamut());
+    /// ```
+    pub fn is_in_gamut(&self) -> bool {
+        self.values().iter().all(|v| (0.0..=1.0).contains(v))
+    }
+
+    /// Returns itself as an [`Rgb`] instance with all channel values unchanged, if this wide RGB
+    /// instance is in the RGB gamut (all channel values within the `[0.0, 1.0]` range).
+    /// If this wide RGB instance is out-of-gamut, `None` is returned.
+    ///
+    /// ```rust
+    /// # use colorimetry::rgb::WideRgb;
+    ///
+    /// let wide_rgb = WideRgb::new(1.0, 0.2, 0.8, None, None);
+    /// let rgb = wide_rgb.to_rgb().unwrap();
+    /// assert_eq!(rgb.values(), wide_rgb.values());
+    ///
+    /// // A `WideRgb` value with out-of-gamut components.
+    /// let wide_rgb = WideRgb::new(1.2, -0.5, 0.8, None, None);
+    /// assert!(wide_rgb.to_rgb().is_none());
+    /// ```
+    pub fn to_rgb(self) -> Option<Rgb> {
+        if self.is_in_gamut() {
+            Some(Rgb {
+                rgb: self.rgb,
+                observer: self.observer,
+                space: self.space,
+            })
+        } else {
+            None
+        }
+    }
+
     /// Converts a `WideRgb` value to a valid `Rgb` value by clamping red, green, and blue values to the range [0, 1].
     ///
     /// ```rust


### PR DESCRIPTION
Sometimes you want to check if a `WideRgb` instance is in-gamut or not. And if it is, operate on the corresponding `Rgb` instance. This is a simple helper to do that. Since we have conversion `WideRgb -> Rgb` with channel modification I think we should also have one that guarantees channel values stays the same, but indicate out-of-gamut with the type instead (`Option<Rgb>`).

EDIT: I also added a `is_in_gamut` method. I thought it could be helpful, and it also made the implementation of `to_rgb` cleaner at the same time.