### PR TITLE
Adding `RelXYZ` to represent related colors, with a common white point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-### Documentation
-
 ### Added
 - `Gaussian` struct, to represent normal distributions as used in this library as spectral
   distributions and used for filtering.
@@ -28,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add `WideRgb::to_rgb` that returns an `Rgb` instance with the same channel values, if the wide
   RGB was not out-of-gamut.
 - Add `WideRgb::is_in_gamut` to check if the RGB values are within the RGB gamut.
+- Add `RelXYZ` to represent related colors, sharing a single white reference
 
 ### Changed
 - Refactored `physics.rs` with the planck functions and LED functions now moved to the `Illuminant` module,
@@ -45,6 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Mark all enums that might get new variants in future non-API breaking releases as
   `#[non_exhaustive]`. This includes `RgbSpace`, `Cam` and `Error`.
 - Renamed `CES_DATA` to `CES`
+- `CieCam02`, `CieCam03` and `CieLab` constructors now taking a single `RelXYZ` argument, instead of two `XYZ` values.
 
 ### Removed
 - Various normal distribution (gaussian) helper functions, now all collected as methods of the `Gaussian` struct.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ In practical terms, a ΔE of 3 is considered a close match—just at the thresho
     None,
     Some(Cie2015_10),
   ).unwrap();
-  // ("5R4/14", 3.0)
+  // ("5R4/14", 2.85)
 ```
 </details>
 

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -226,7 +226,7 @@ impl CamJCh {
         };
         let xyz_out = XYZ::from_vecs(xyz, self.xyzn.observer);
         let xyzn_out = XYZ::from_vecs(xyzn, self.xyzn.observer);
-        Ok(RelXYZ::new(xyz_out, xyzn_out)?)
+        RelXYZ::from_xyz(xyz_out, xyzn_out)
     }
 
     pub fn rgb(

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -87,23 +87,11 @@ impl CamJCh {
     const DEN1: f64 = ((2.0 + Self::P3) * 220.0) / 1403.0;
     const DEN2: f64 = (Self::P3 * 6300.0 - 27.0) / 1403.0;
 
-    pub fn new(
-        jch: Vector3<f64>,
-        xyzn: XYZ,
-        vc: ViewConditions,
-    ) -> Self {
-        Self {
-            jch,
-            xyzn,
-            vc,
-        }
+    pub fn new(jch: Vector3<f64>, xyzn: XYZ, vc: ViewConditions) -> Self {
+        Self { jch, xyzn, vc }
     }
 
-    pub fn from_xyz(
-        rxyz : RelXYZ,
-        vc: ViewConditions,
-        cam: Cam,
-    ) -> Self {
+    pub fn from_xyz(rxyz: RelXYZ, vc: ViewConditions, cam: Cam) -> Self {
         let xyz_vec = rxyz.xyz().xyz;
 
         let ReferenceValues {
@@ -161,7 +149,7 @@ impl CamJCh {
         Self {
             vc,
             jch: Vector3::new(jj, cc, h * 180.0 / PI),
-            xyzn: rxyz.white_point()
+            xyzn: rxyz.white_point(),
         }
     }
 

--- a/src/cam.rs
+++ b/src/cam.rs
@@ -41,22 +41,18 @@ pub use crate::cam::cam02::CieCam02;
 use crate::{
     observer::Observer,
     rgb::{RgbSpace, WideRgb},
-    xyz::XYZ,
+    xyz::{RelXYZ, XYZ},
 };
 use nalgebra::{matrix, vector, SMatrix, Vector3};
 use std::f64::consts::PI;
 
 #[derive(Debug)]
 pub struct CamJCh {
-    /// Colorimetric Observer used.
-    /// The standard requires use of the CIE1931 standard observer.
-    observer: Observer,
-
     /// Correlates of Lightness, Chroma, and hue-angle
     jch: Vector3<f64>,
 
     /// Tristimulus values of the reference white being use
-    xyzn: Vector3<f64>,
+    xyzn: XYZ,
 
     /// Viewing Conditions
     vc: ViewConditions,
@@ -92,13 +88,11 @@ impl CamJCh {
     const DEN2: f64 = (Self::P3 * 6300.0 - 27.0) / 1403.0;
 
     pub fn new(
-        observer: Observer,
         jch: Vector3<f64>,
-        xyzn: Vector3<f64>,
+        xyzn: XYZ,
         vc: ViewConditions,
     ) -> Self {
         Self {
-            observer,
             jch,
             xyzn,
             vc,
@@ -106,16 +100,11 @@ impl CamJCh {
     }
 
     pub fn from_xyz(
-        xyz: XYZ,
-        xyzn: XYZ,
+        rxyz : RelXYZ,
         vc: ViewConditions,
         cam: Cam,
-    ) -> Result<Self, crate::Error> {
-        if xyz.observer != xyzn.observer {
-            return Err(crate::Error::RequireSameObserver);
-        }
-        let xyz_vec = xyz.xyz;
-        let xyzn_vec = xyzn.xyz;
+    ) -> Self {
+        let xyz_vec = rxyz.xyz().xyz;
 
         let ReferenceValues {
             n,
@@ -125,9 +114,7 @@ impl CamJCh {
             d_rgb,
             aw,
             qu,
-        } = vc.reference_values(xyzn.xyz, cam);
-        //  let vcdd = vc.dd();
-        //  let vcfl = vc.f_l();
+        } = vc.reference_values(rxyz.white_point().xyz, cam);
 
         let mut rgb = match cam {
             Cam::CieCam16 => M16 * xyz_vec,
@@ -171,12 +158,11 @@ impl CamJCh {
             / (rgb[0] + rgb[1] + 21.0 / 20.0 * rgb[2]);
         let cc = t.powf(0.9) * (jj / 100.).sqrt() * (1.64 - (0.29f64).powf(n)).powf(0.73);
 
-        Ok(Self {
+        Self {
             vc,
             jch: Vector3::new(jj, cc, h * 180.0 / PI),
-            observer: xyz.observer,
-            xyzn: xyzn_vec,
-        })
+            xyzn: rxyz.white_point()
+        }
     }
 
     pub fn xyz(
@@ -184,16 +170,16 @@ impl CamJCh {
         opt_xyzn: Option<XYZ>,
         opt_viewconditions: Option<ViewConditions>,
         cam: Cam,
-    ) -> Result<XYZ, crate::Error> {
+    ) -> Result<RelXYZ, crate::Error> {
         let vc = opt_viewconditions.unwrap_or_default();
         let xyzn = if let Some(white) = opt_xyzn {
-            if white.observer == self.observer {
+            if white.observer == self.xyzn.observer {
                 white.xyz
             } else {
                 return Err(crate::Error::RequireSameObserver);
             }
         } else {
-            self.xyzn
+            self.xyzn.xyz
         };
         let ReferenceValues {
             n,
@@ -238,7 +224,9 @@ impl CamJCh {
                 MCAT02INV * rgb_c
             }
         };
-        Ok(XYZ::from_vecs(xyz, self.observer))
+        let xyz_out = XYZ::from_vecs(xyz, self.xyzn.observer);
+        let xyzn_out = XYZ::from_vecs(xyzn, self.xyzn.observer);
+        Ok(RelXYZ::new(xyz_out, xyzn_out)?)
     }
 
     pub fn rgb(
@@ -248,10 +236,10 @@ impl CamJCh {
         cam: Cam,
     ) -> Result<WideRgb, crate::Error> {
         let viewconditions = opt_viewconditions.unwrap_or_default();
-        let observer = self.observer;
+        let observer = self.xyzn.observer;
         let xyzn = observer.xyz(&rgbspace.white(), None).set_illuminance(100.0);
         let xyz = self.xyz(Some(xyzn), Some(viewconditions), cam)?;
-        Ok(xyz.rgb(rgbspace))
+        Ok(xyz.xyz().rgb(rgbspace))
     }
 }
 

--- a/src/cam/cam02.rs
+++ b/src/cam/cam02.rs
@@ -58,7 +58,7 @@ impl CieCam02 {
     pub fn new(jch: [f64; 3], xyzn: XYZ, vc: ViewConditions) -> Self {
         Self(CamJCh {
             jch: Vector3::from(jch),
-            xyzn: xyzn,
+            xyzn,
             vc,
         })
     }
@@ -158,9 +158,8 @@ mod cam02_test {
     // Worked example from CIECAM02 documentation, CIE159:2004, p. 11
     fn test_worked_example() {
         // forward transform (XYZ -> JCh)
-        let xyz = XYZ::new([19.31, 23.93, 10.14], Observer::Cie1931);
-        let xyzn = XYZ::new([98.88, 90.0, 32.03], Observer::Cie1931);
-        let rxyz = RelXYZ::new(xyz, xyzn).unwrap();
+        let white_point = XYZ::new([98.88, 90.0, 32.03], Observer::Cie1931);
+        let rxyz = RelXYZ::new([19.31, 23.93, 10.14], white_point);
         // Table 4, column 2, CIE 159:2004.
         // La = 20 cd/m2;
         let vc = ViewConditions::new(20.0, 18.0, 0.69, 1.0, 1.0, None);
@@ -216,7 +215,7 @@ mod cam02_round_trip_tests {
             // forward transform (XYZ -> JCh)
             let xyz = XYZ::new(xyz_arr, Observer::Cie1931);
             let xyz_d65 = Cie1931.xyz_d65();
-            let rxyz = RelXYZ::new(xyz, xyz_d65).unwrap();
+            let rxyz = RelXYZ::from_xyz(xyz, xyz_d65).unwrap();
             let cam = CieCam02::from_xyz(rxyz,ViewConditions::default());
             let jch = cam.jch();
 

--- a/src/cam/cam02.rs
+++ b/src/cam/cam02.rs
@@ -216,7 +216,7 @@ mod cam02_round_trip_tests {
             let xyz = XYZ::new(xyz_arr, Observer::Cie1931);
             let xyz_d65 = Cie1931.xyz_d65();
             let rxyz = RelXYZ::from_xyz(xyz, xyz_d65).unwrap();
-            let cam = CieCam02::from_xyz(rxyz,ViewConditions::default());
+            let cam = CieCam02::from_xyz(rxyz, ViewConditions::default());
             let jch = cam.jch();
 
             // inverse (JCh -> XYZ)

--- a/src/cam/cam02.rs
+++ b/src/cam/cam02.rs
@@ -8,25 +8,6 @@
 //! - **Inverse transform** back to XYZ with optional new white or viewing conditions via `xyz`.  
 //! - **Chromatic adaptation** using CIECAT02 matrices  
 //! - Utility functions for achromatic response, eccentricity, and more  
-//!
-//! ## Example
-//! ```rust
-//! use colorimetry::cam::CieCam02;
-//! use colorimetry::cam::ViewConditions;
-//! use colorimetry::xyz::XYZ;
-//! use colorimetry::cam::CamTransforms;
-//! use colorimetry::observer::Observer;
-//!
-//! let sample = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
-//! let white  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
-//! let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
-//!
-//! let cam = CieCam02::from_xyz(sample, white, vc).unwrap();
-//! let jch = cam.jch();
-//! println!("JCh: {:?}", jch);
-//! ```
-//!
-//! *Methods and internals marked `pub(crate)` have been omitted for brevity.*
 
 use super::{CamJCh, CamTransforms, ViewConditions};
 
@@ -36,7 +17,7 @@ use crate::{
     error::Error,
     observer::Observer,
     rgb::{RgbSpace, WideRgb},
-    xyz::XYZ,
+    xyz::{RelXYZ, XYZ},
 };
 
 /// CIECAM02 Color Appearance Model
@@ -77,9 +58,8 @@ impl CieCam02 {
     pub fn new(jch: [f64; 3], xyzn: XYZ, vc: ViewConditions) -> Self {
         Self(CamJCh {
             jch: Vector3::from(jch),
-            xyzn: xyzn.xyz,
+            xyzn: xyzn,
             vc,
-            observer: xyzn.observer,
         })
     }
 
@@ -94,9 +74,8 @@ impl CieCam02 {
     /// A Result containing the CieCam02 instance if successful, or a CmtError if an error occurs.
     /// # Errors
     /// Returns an error if the XYZ values are not in the same observer system.
-    pub fn from_xyz(xyz: XYZ, xyzn: XYZ, vc: ViewConditions) -> Result<Self, Error> {
-        let camjch = CamJCh::from_xyz(xyz, xyzn, vc, super::Cam::CieCam02)?;
-        Ok(Self(camjch))
+    pub fn from_xyz(rxyz: RelXYZ, vc: ViewConditions) -> Self {
+        Self(CamJCh::from_xyz(rxyz, vc, super::Cam::CieCam02))
     }
 
     /// Inverse-transform CIECAM02 appearance correlates back to CIE XYZ tristimulus values.
@@ -120,31 +99,11 @@ impl CieCam02 {
     /// # Returns
     /// - `Ok(XYZ)`: the reconstructed tristimulus values under the specified (or original) conditions.  
     /// - `Err(CmtError::RequireSameObserver)`: if `white_opt` has a different `Observer` than `self`.
-    ///
-    /// # Example
-    /// ```rust
-    /// use colorimetry::cam::CieCam02;
-    /// use colorimetry::cam::ViewConditions;
-    /// use colorimetry::xyz::XYZ;
-    /// use colorimetry::observer::Observer;
-    /// // Original CAM16 instance:
-    /// let sample_xyz = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
-    /// let white_xyz  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
-    /// let vc = ViewConditions::new(40.0, 16.0, 0.69, 1.0, 1.0, None);
-    /// let cam = CieCam02::from_xyz(sample_xyz, white_xyz, vc).unwrap();
-    ///
-    /// // Inverse under same conditions:
-    /// let back_to_xyz = cam.xyz(None, None).unwrap();
-    ///
-    /// // Inverse with a new white point:
-    /// let new_white = XYZ::new([95.0, 100.0, 108.0], Observer::Cie1931);
-    /// let adapted_xyz = cam.xyz(Some(new_white), None).unwrap();
-    /// ```
     pub fn xyz(
         &self,
         opt_xyzn: Option<XYZ>,
         opt_viewconditions: Option<ViewConditions>,
-    ) -> Result<XYZ, Error> {
+    ) -> Result<RelXYZ, Error> {
         self.0
             .xyz(opt_xyzn, opt_viewconditions, super::Cam::CieCam02)
     }
@@ -173,11 +132,11 @@ impl CamTransforms for CieCam02 {
 
     /// Returns the observer of this CieCam02 instance.
     fn observer(&self) -> Observer {
-        self.0.observer
+        self.0.xyzn.observer
     }
 
     fn xyzn(&self) -> &Vector3<f64> {
-        &self.0.xyzn
+        &self.0.xyzn.xyz
     }
 }
 
@@ -188,7 +147,7 @@ mod cam02_test {
 
     use crate::cam::{CamTransforms, CieCam02, ViewConditions, M16, M16INV};
     use crate::observer::Observer;
-    use crate::xyz::XYZ;
+    use crate::xyz::{RelXYZ, XYZ};
 
     #[test]
     fn test_m16() {
@@ -201,11 +160,11 @@ mod cam02_test {
         // forward transform (XYZ -> JCh)
         let xyz = XYZ::new([19.31, 23.93, 10.14], Observer::Cie1931);
         let xyzn = XYZ::new([98.88, 90.0, 32.03], Observer::Cie1931);
-
+        let rxyz = RelXYZ::new(xyz, xyzn).unwrap();
         // Table 4, column 2, CIE 159:2004.
         // La = 20 cd/m2;
         let vc = ViewConditions::new(20.0, 18.0, 0.69, 1.0, 1.0, None);
-        let cam = CieCam02::from_xyz(xyz, xyzn, vc).unwrap();
+        let cam = CieCam02::from_xyz(rxyz, vc);
         let jch = cam.jch_vec();
         let &[j, c, h] = jch.as_ref();
         assert_abs_diff_eq!(j, 47.6856, epsilon = 1E-4); // J
@@ -215,7 +174,7 @@ mod cam02_test {
         // Table 4, column 3, CIE 159:2004.
         // La = 200 cd/m2;
         let vc = ViewConditions::new(200.0, 18.0, 0.69, 1.0, 1.0, None);
-        let cam = CieCam02::from_xyz(xyz, xyzn, vc).unwrap();
+        let cam = CieCam02::from_xyz(rxyz, vc);
         let jch = cam.jch_vec();
         let &[j, c, h] = jch.as_ref();
         assert_abs_diff_eq!(j, 48.0314, epsilon = 1E-4); // J
@@ -227,10 +186,9 @@ mod cam02_test {
 #[cfg(test)]
 mod cam02_round_trip_tests {
     use crate::{
-        cam::CieCam02,
-        cam::{CamTransforms, ViewConditions},
-        observer::{Observer, Observer::Cie1931},
-        xyz::XYZ,
+        cam::{CamTransforms, CieCam02, ViewConditions},
+        observer::Observer::{self, Cie1931},
+        xyz::{RelXYZ, XYZ},
     };
     use approx::assert_abs_diff_eq;
 
@@ -258,7 +216,8 @@ mod cam02_round_trip_tests {
             // forward transform (XYZ -> JCh)
             let xyz = XYZ::new(xyz_arr, Observer::Cie1931);
             let xyz_d65 = Cie1931.xyz_d65();
-            let cam = CieCam02::from_xyz(xyz, xyz_d65, ViewConditions::default()).unwrap();
+            let rxyz = RelXYZ::new(xyz, xyz_d65).unwrap();
+            let cam = CieCam02::from_xyz(rxyz,ViewConditions::default());
             let jch = cam.jch();
 
             // inverse (JCh -> XYZ)
@@ -266,13 +225,7 @@ mod cam02_round_trip_tests {
             let xyz_back = cam_back.xyz(None, None).unwrap();
 
             // compare original vs. round-tripped XYZ
-            let orig = XYZ::new(xyz_arr, Observer::Cie1931);
-            let [x0, y0, z0] = orig.values();
-            let [x1, y1, z1] = xyz_back.values();
-
-            assert_abs_diff_eq!(x0, x1, epsilon = 1e-6);
-            assert_abs_diff_eq!(y0, y1, epsilon = 1e-6);
-            assert_abs_diff_eq!(z0, z1, epsilon = 1e-6);
+            assert_abs_diff_eq!(rxyz, xyz_back, epsilon = 1e-6);
         }
     }
 }

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -188,7 +188,7 @@ mod cam16_test {
         // see section 7 CIE 248:2022
         let xyz = XYZ::new([60.70, 49.60, 10.29], Observer::Cie1931);
         let xyzn = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
-        let rxyz = RelXYZ::new(xyz, xyzn).unwrap();
+        let rxyz = RelXYZ::from_xyz(xyz, xyzn).unwrap();
         let vc = ViewConditions::new(40.0, 16.0, 0.69, 1.0, 1.0, None);
         let cam = CieCam16::from_xyz(rxyz, vc);
         let &[j, c, h] = cam.jch_vec().as_ref();
@@ -234,7 +234,7 @@ mod cam16_round_trip_tests {
             // forward transform (XYZ -> JCh)
             let xyz = XYZ::new(xyz_arr, Cie1931);
             let xyz_d65 = Cie1931.xyz_d65();
-            let rxyz = RelXYZ::new(xyz, xyz_d65).unwrap();
+            let rxyz = RelXYZ::from_xyz(xyz, xyz_d65).unwrap();
             let cam = CieCam16::from_xyz(rxyz, ViewConditions::default());
             let jch = cam.jch();
 

--- a/src/cam/cam16.rs
+++ b/src/cam/cam16.rs
@@ -9,25 +9,6 @@
 //! - **Chromatic adaptation** using CIECAT02 matrices  
 //! - Utility functions for achromatic response, eccentricity, and more  
 //!
-//! ## Example
-//! ```rust
-//! use colorimetry::cam::CieCam16;
-//! use colorimetry::cam::ViewConditions;
-//! use colorimetry::xyz::XYZ;
-//! use colorimetry::cam::CamTransforms;
-//! use colorimetry::observer::Observer;
-//!
-//! let sample = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
-//! let white  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
-//! let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
-//!
-//! let cam = CieCam16::from_xyz(sample, white, vc).unwrap();
-//! let jch = cam.jch();
-//! println!("JCh: {:?}", jch);
-//! ```
-//!
-//! *Methods and internals marked `pub(crate)` have been omitted for brevity.*
-
 use super::{CamJCh, CamTransforms, ViewConditions};
 
 use nalgebra::Vector3;
@@ -36,7 +17,7 @@ use crate::{
     error::Error,
     observer::Observer,
     rgb::{RgbSpace, WideRgb},
-    xyz::XYZ,
+    xyz::{RelXYZ, XYZ},
 };
 
 /// CIECAM16 Color Appearance Model
@@ -77,9 +58,8 @@ impl CieCam16 {
     pub fn new(jch: [f64; 3], xyzn: XYZ, vc: ViewConditions) -> Self {
         Self(CamJCh {
             jch: Vector3::from(jch),
-            xyzn: xyzn.xyz,
+            xyzn,
             vc,
-            observer: xyzn.observer,
         })
     }
 
@@ -94,9 +74,8 @@ impl CieCam16 {
     /// A Result containing the CieCam16 instance if successful, or a CmtError if an error occurs.
     /// # Errors
     /// Returns an error if the XYZ values are not in the same observer system.
-    pub fn from_xyz(xyz: XYZ, xyzn: XYZ, vc: ViewConditions) -> Result<Self, Error> {
-        let camjch = CamJCh::from_xyz(xyz, xyzn, vc, super::Cam::CieCam16)?;
-        Ok(Self(camjch))
+    pub fn from_xyz(rxyz: RelXYZ, vc: ViewConditions) -> Self {
+        Self(CamJCh::from_xyz(rxyz, vc, super::Cam::CieCam16))
     }
 
     /// Inverse-transform CIECAM16 appearance correlates back to CIE XYZ tristimulus values.
@@ -120,28 +99,11 @@ impl CieCam16 {
     /// # Returns
     /// - `Ok(XYZ)`: the reconstructed tristimulus values under the specified (or original) conditions.  
     /// - `Err(CmtError::RequireSameObserver)`: if `white_opt` has a different `Observer` than `self`.
-    ///
-    /// # Example
-    /// ```rust
-    /// use colorimetry::prelude::*;
-    /// // Original CAM16 instance:
-    /// let sample_xyz = XYZ::new([60.7, 49.6, 10.3], Observer::Cie1931);
-    /// let white_xyz  = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
-    /// let vc     = ViewConditions::new(16.0, 1.0, 1.0, 0.69, 40.0, None);
-    /// let cam = CieCam16::from_xyz(sample_xyz, white_xyz, vc).unwrap();
-    ///
-    /// // Inverse under same conditions:
-    /// let back_to_xyz = cam.xyz(None, None).unwrap();
-    ///
-    /// // Inverse with a new white point:
-    /// let new_white = XYZ::new([95.0, 100.0, 108.0], Observer::Cie1931);
-    /// let adapted_xyz = cam.xyz(Some(new_white), None).unwrap();
-    /// ```
     pub fn xyz(
         &self,
         opt_xyzn: Option<XYZ>,
         opt_viewconditions: Option<ViewConditions>,
-    ) -> Result<XYZ, Error> {
+    ) -> Result<RelXYZ, Error> {
         self.0
             .xyz(opt_xyzn, opt_viewconditions, super::Cam::CieCam16)
     }
@@ -199,11 +161,11 @@ impl CamTransforms for CieCam16 {
 
     /// Returns the observer of this CieCam16 instance.
     fn observer(&self) -> Observer {
-        self.0.observer
+        self.0.xyzn.observer
     }
 
     fn xyzn(&self) -> &Vector3<f64> {
-        &self.0.xyzn
+        &self.0.xyzn.xyz
     }
 }
 
@@ -214,7 +176,7 @@ mod cam16_test {
 
     use crate::cam::{CamTransforms, CieCam16, ViewConditions, M16, M16INV};
     use crate::observer::Observer;
-    use crate::xyz::XYZ;
+    use crate::xyz::{RelXYZ, XYZ};
 
     #[test]
     fn test_m16() {
@@ -226,8 +188,9 @@ mod cam16_test {
         // see section 7 CIE 248:2022
         let xyz = XYZ::new([60.70, 49.60, 10.29], Observer::Cie1931);
         let xyzn = XYZ::new([96.46, 100.0, 108.62], Observer::Cie1931);
+        let rxyz = RelXYZ::new(xyz, xyzn).unwrap();
         let vc = ViewConditions::new(40.0, 16.0, 0.69, 1.0, 1.0, None);
-        let cam = CieCam16::from_xyz(xyz, xyzn, vc).unwrap();
+        let cam = CieCam16::from_xyz(rxyz, vc);
         let &[j, c, h] = cam.jch_vec().as_ref();
         //println!("J:\t{j:?}\nC:\t{c:?}\nh:\t{h:?}");
         approx::assert_abs_diff_eq!(j, 70.4406, epsilon = 1E-4);
@@ -236,7 +199,7 @@ mod cam16_test {
 
         // inverse transformation, with no change in white adaptation of viewing conditions.
         let xyz_rev = cam.xyz(None, Some(vc)).unwrap();
-        assert_abs_diff_eq!(xyz, xyz_rev, epsilon = 1E-4);
+        assert_abs_diff_eq!(rxyz, xyz_rev, epsilon = 1E-4);
     }
 }
 
@@ -244,6 +207,7 @@ mod cam16_test {
 mod cam16_round_trip_tests {
     use crate::observer::Observer::Cie1931;
     use crate::prelude::*;
+    use crate::xyz::RelXYZ;
     use approx::assert_abs_diff_eq;
 
     #[test]
@@ -270,21 +234,16 @@ mod cam16_round_trip_tests {
             // forward transform (XYZ -> JCh)
             let xyz = XYZ::new(xyz_arr, Cie1931);
             let xyz_d65 = Cie1931.xyz_d65();
-            let cam = CieCam16::from_xyz(xyz, xyz_d65, ViewConditions::default()).unwrap();
+            let rxyz = RelXYZ::new(xyz, xyz_d65).unwrap();
+            let cam = CieCam16::from_xyz(rxyz, ViewConditions::default());
             let jch = cam.jch();
 
             // inverse (JCh -> XYZ)
             let cam_back = CieCam16::new(jch, xyz_d65, ViewConditions::default());
-            let xyz_back = cam_back.xyz(None, None).unwrap();
+            let rxyz_back = cam_back.xyz(None, None).unwrap();
 
             // compare original vs. round-tripped XYZ
-            let orig = XYZ::new(xyz_arr, Cie1931);
-            let [x0, y0, z0] = orig.values();
-            let [x1, y1, z1] = xyz_back.values();
-
-            assert_abs_diff_eq!(x0, x1, epsilon = 1e-6);
-            assert_abs_diff_eq!(y0, y1, epsilon = 1e-6);
-            assert_abs_diff_eq!(z0, z1, epsilon = 1e-6);
+            assert_abs_diff_eq!(rxyz, rxyz_back, epsilon = 1e-6);
         }
     }
 }

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -194,10 +194,8 @@ impl Colorant {
     pub fn cielab(&self, illuminant_opt: Option<&dyn Light>, obs_opt: Option<Observer>) -> CieLab {
         let illuminant = illuminant_opt.unwrap_or(&crate::illuminant::D65);
         let obs = obs_opt.unwrap_or_default();
-        let xyzn = obs.xyz(illuminant, None).set_illuminance(100.0);
-        let xyz = obs.xyz(illuminant, Some(self));
-        // unwrap is safe here, as we know the illuminant and observer are valid
-        CieLab::from_xyz(xyz, xyzn).unwrap()
+        let rxyz = obs.rel_xyz(illuminant, self);
+        CieLab::from_xyz(rxyz)
     }
 }
 

--- a/src/colorant/munsell.rs
+++ b/src/colorant/munsell.rs
@@ -133,15 +133,13 @@ impl MunsellCollection {
         let illuminant = opt_illuminant.unwrap_or(&D65);
         let vc = opt_vc.unwrap_or_default();
         let observer = opt_observer.unwrap_or_default();
-
-        let xyz = observer.xyz(illuminant, Some(colorant));
-        let xyzn = observer.xyz(illuminant, None);
-        let tgt_cam = CieCam16::from_xyz(xyz, xyzn, vc)?;
+        let rxyz = observer.rel_xyz(illuminant, colorant);
+        let tgt_cam = CieCam16::from_xyz(rxyz, vc);
         let mut best_key = String::new();
         let mut best_delta_e = f64::MAX;
         for mm in MunsellCollection.into_iter() {
-            let xyz_mm = observer.xyz(illuminant, Some(&mm));
-            let cam_mm = CieCam16::from_xyz(xyz_mm, xyzn, vc)?;
+            let xyz_mm = observer.rel_xyz(illuminant, &mm);
+            let cam_mm = CieCam16::from_xyz(xyz_mm, vc);
             let delta_e = tgt_cam.de_ucs(&cam_mm)?;
             if delta_e < best_delta_e {
                 best_delta_e = delta_e;
@@ -244,6 +242,6 @@ mod test_munsell {
         let r9 = &crate::colorant::tcs::TCS[8];
         let (key, delta_e) = MunsellCollection::match_ciecam16(r9, None, None, None).unwrap();
         assert_eq!(key, "5R4/14");
-        approx::assert_abs_diff_eq!(delta_e, 3.0, epsilon = 5e-2);
+        approx::assert_abs_diff_eq!(delta_e, 2.8, epsilon = 5e-2);
     }
 }

--- a/src/illuminant/cfi.rs
+++ b/src/illuminant/cfi.rs
@@ -58,12 +58,12 @@ impl CFI {
         let mut jabp_rs = [[0f64; 3]; N_CFI];
         for (i, cfi_ces) in CES.iter().enumerate() {
             let xyz_t = Cie1964.xyz(illuminant, Some(cfi_ces));
-            let rxyz_t = RelXYZ::new(xyz_t, xyzn_t)?;
+            let rxyz_t = RelXYZ::from_xyz(xyz_t, xyzn_t)?;
             let jabp_t = CieCam02::from_xyz(rxyz_t, vc).jab_prime();
             jabp_ts[i] = jabp_t;
 
             let xyz_r = Cie1964.xyz(&ref_illuminant, Some(cfi_ces));
-            let rxyz_r = RelXYZ::new(xyz_r, xyzn_r)?;
+            let rxyz_r = RelXYZ::from_xyz(xyz_r, xyzn_r)?;
             let jabp_r = CieCam02::from_xyz(rxyz_r, vc).jab_prime();
             jabp_rs[i] = jabp_r;
         }

--- a/src/illuminant/cfi.rs
+++ b/src/illuminant/cfi.rs
@@ -1,5 +1,6 @@
 use crate::math::distance;
 use crate::observer::Observer::Cie1964;
+use crate::xyz::RelXYZ;
 use crate::{
     cam::{CamTransforms, CieCam02, TM30VC},
     colorant::{CES, N_CFI},
@@ -57,11 +58,13 @@ impl CFI {
         let mut jabp_rs = [[0f64; 3]; N_CFI];
         for (i, cfi_ces) in CES.iter().enumerate() {
             let xyz_t = Cie1964.xyz(illuminant, Some(cfi_ces));
-            let jabp_t = CieCam02::from_xyz(xyz_t, xyzn_t, vc)?.jab_prime();
+            let rxyz_t = RelXYZ::new(xyz_t, xyzn_t)?;
+            let jabp_t = CieCam02::from_xyz(rxyz_t, vc).jab_prime();
             jabp_ts[i] = jabp_t;
 
             let xyz_r = Cie1964.xyz(&ref_illuminant, Some(cfi_ces));
-            let jabp_r = CieCam02::from_xyz(xyz_r, xyzn_r, vc)?.jab_prime();
+            let rxyz_r = RelXYZ::new(xyz_r, xyzn_r)?;
+            let jabp_r = CieCam02::from_xyz(rxyz_r, vc).jab_prime();
             jabp_rs[i] = jabp_r;
         }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -36,8 +36,8 @@ use crate::{error::Error, xyz::{RelXYZ, XYZ}};
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy)]
 pub struct CieLab {
-    pub(crate) lab: Vector3<f64>,
-    pub(crate) xyzn: XYZ, // Reference white tristimulus value
+    lab: Vector3<f64>,
+    xyzn: XYZ, // Reference white tristimulus value
 }
 
 impl CieLab {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -25,26 +25,7 @@
 //!
 //! - **WASM bindings**  
 //!   Exported via `#[wasm_bindgen]` for JavaScript interoperability.
-//!
-//! ## Examples
-//!
-//! ```rust
-//! use colorimetry::prelude::*;
-//!
-//! // Convert XYZ to Lab
-//! let xyz = XYZ::new([36.0, 70.0, 12.0], Observer::Cie1931);
-//! let rxyz = RelXYZ::with_d65(xyz);
-//! let lab1 = CieLab::from_xyz(rxyz);
-//!
-//! // Direct Lab constructor
-//! let white = Cie1931.xyz_d65(); // Reference white point (D65 illuminant)
-//! let lab2 = CieLab::new([50.0, 20.0, 30.0], white);
-//!
-//! // Compute differences
-//! let d_ab   = lab1.ciede(&lab2).unwrap();      // Euclidean ΔE*ab
-//! let d_2000 = lab1.ciede2000(&lab2).unwrap();  // CIEDE2000 ΔE
-//! println!("ΔE*ab = {:.2}, ΔE₀₀ = {:.2}", d_ab, d_2000);
-//! ```
+//! 
 
 use approx::ulps_eq;
 use nalgebra::Vector3;
@@ -71,7 +52,7 @@ impl CieLab {
         let lab = Vector3::from(lab);
         CieLab {
             lab,
-            xyzn: xyzn
+            xyzn
         }
     }
 
@@ -97,7 +78,7 @@ impl CieLab {
         // Convert back to XYZ for any further processing
         let xyz = xyz_from_cielab(self.lab, self.xyzn.xyz);
         // unwrap - same observer
-        RelXYZ::new(XYZ::from_vecs(xyz, self.xyzn.observer ), self.xyzn).unwrap()
+        RelXYZ::from_xyz(XYZ::from_vecs(xyz, self.xyzn.observer ), self.xyzn).unwrap()
     }
 
     /// Sets the reference white luminance for this CIE L*a*b* color, in units of cd/m².
@@ -373,8 +354,7 @@ mod tests {
     fn lab_roundtrip_test() {
         let xyz_values = [36.0, 70.0, 12.0];
         let xyz = XYZ::new(xyz_values, Cie1931);
-        let white = Cie1931.xyz_d65(); // Reference white point (D65 illuminant)
-        let rxyz = RelXYZ::new(xyz, white).unwrap();
+        let rxyz = RelXYZ::with_d65(xyz);
         let lab = CieLab::from_xyz(rxyz);
         let rxyz_back = lab.xyz();
         assert_abs_diff_eq!(rxyz, rxyz_back, epsilon = 1e-10);

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -129,7 +129,8 @@ impl CieLab {
     /// let lab1 = CieLab::from_xyz(RelXYZ::with_d65(xyz1));
     /// let lab2 = CieLab::from_xyz(RelXYZ::with_d65(xyz2));
     /// let de = lab1.ciede(&lab2).unwrap();
-    /// approx::assert_abs_diff_eq!(de, 6.57, epsilon = 0.01);
+    /// # approx::assert_abs_diff_eq!(de, 6.57, epsilon = 0.01);
+    /// //  ΔE=6.57
     /// ```
     pub fn ciede(&self, other: &Self) -> Result<f64, Error> {
         if self.xyzn.observer != other.xyzn.observer {
@@ -237,7 +238,7 @@ fn lab(xyz: Vector3<f64>, xyzn: Vector3<f64>) -> Vector3<f64> {
 ///   out – e.g. Yn = 100 for 0-to-100 “percent” data or Yn = 1.0 for ICC/PCS-scaled values)
 ///
 /// Returns XYZ in the same scaling as `xyzn`.
-pub fn xyz_from_cielab(lab: Vector3<f64>, xyzn: Vector3<f64>) -> Vector3<f64> {
+fn xyz_from_cielab(lab: Vector3<f64>, xyzn: Vector3<f64>) -> Vector3<f64> {
     // CIE constants
     const EPS: f64 = 216.0 / 24_389.0; // δ³  (≈ 0.008856)
     const KAPPA: f64 = 24_389.0 / 27.0; // κ  (≈ 903.296 3)

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -25,13 +25,16 @@
 //!
 //! - **WASM bindings**  
 //!   Exported via `#[wasm_bindgen]` for JavaScript interoperability.
-//! 
+//!
 
 use approx::ulps_eq;
 use nalgebra::Vector3;
 use std::f64::consts::PI;
 
-use crate::{error::Error, xyz::{RelXYZ, XYZ}};
+use crate::{
+    error::Error,
+    xyz::{RelXYZ, XYZ},
+};
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Clone, Copy)]
@@ -50,10 +53,7 @@ impl CieLab {
     /// A new `CieLab` instance.
     pub fn new(lab: [f64; 3], xyzn: XYZ) -> CieLab {
         let lab = Vector3::from(lab);
-        CieLab {
-            lab,
-            xyzn
-        }
+        CieLab { lab, xyzn }
     }
 
     /// Creates a new CIE L*a*b* color from the given XYZ color and reference white.
@@ -67,7 +67,7 @@ impl CieLab {
     pub fn from_xyz(xyz: RelXYZ) -> CieLab {
         CieLab {
             lab: lab(xyz.xyz().xyz, xyz.white_point().xyz),
-            xyzn: xyz.white_point()
+            xyzn: xyz.white_point(),
         }
     }
 
@@ -78,7 +78,7 @@ impl CieLab {
         // Convert back to XYZ for any further processing
         let xyz = xyz_from_cielab(self.lab, self.xyzn.xyz);
         // unwrap - same observer
-        RelXYZ::from_xyz(XYZ::from_vecs(xyz, self.xyzn.observer ), self.xyzn).unwrap()
+        RelXYZ::from_xyz(XYZ::from_vecs(xyz, self.xyzn.observer), self.xyzn).unwrap()
     }
 
     /// Sets the reference white luminance for this CIE L*a*b* color, in units of cd/m².
@@ -346,7 +346,11 @@ fn delta_e_ciede2000(lab1: Vector3<f64>, lab2: Vector3<f64>) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::{lab::CieLab, observer::Observer::Cie1931, xyz::{RelXYZ, XYZ}};
+    use crate::{
+        lab::CieLab,
+        observer::Observer::Cie1931,
+        xyz::{RelXYZ, XYZ},
+    };
     use approx::assert_abs_diff_eq;
     use nalgebra::vector;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,8 +200,8 @@ In practical terms, a ΔE of 3 is considered a close match—just at the thresho
     Some(Cie2015_10),
   ).unwrap();
 # assert_eq!(key, "5R4/14");
-# check!(delta_e, 3.0, epsilon = 5e-2);
-  // ("5R4/14", 3.0)
+# check!(delta_e, 2.85, epsilon = 5e-2);
+  // ("5R4/14", 2.85)
 # }
 ```
 </details>

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -297,7 +297,7 @@ impl Observer {
     pub fn spectral_loci(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
         let xyzn = self.xyz_from_spectrum(ref_white.illuminant().as_ref());
         let scale = 100.0 * self.data().lumconst / xyzn.y();
-        let mut obs = self.data().data.clone();
+        let mut obs = self.data().data;
         let white = &ref_white.illuminant().as_ref().0;
         for r in 0..3 {
             for c in 0..NS {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -165,7 +165,7 @@ impl Observer {
         let xyz = self.xyz_from_spectrum(&s);
         let scale = 100.0 / xyzn.xyz.y;
         // unwrap OK as we are using only one observer (self) here
-        RelXYZ::from_xyz(xyz*scale, xyzn*scale).unwrap()
+        RelXYZ::from_xyz(xyz * scale, xyzn * scale).unwrap()
     }
 
     /*
@@ -492,8 +492,8 @@ mod obs_test {
         let light = CieIlluminant::D65;
         let filter = Colorant::gray(0.5);
 
-        let rxyz= obs.rel_xyz(&light, &filter);
-        assert_ulps_eq!(rxyz.xyz()*2.0, rxyz.white_point(),epsilon = 1E-5);
+        let rxyz = obs.rel_xyz(&light, &filter);
+        assert_ulps_eq!(rxyz.xyz() * 2.0, rxyz.white_point(), epsilon = 1E-5);
         assert_ulps_eq!(rxyz.white_point(), obs.xyz_d65(), epsilon = 1E-5);
     }
 

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -46,7 +46,14 @@
 mod observers;
 
 use crate::{
-    cam::{CieCam02, CieCam16, ViewConditions}, error::Error, illuminant::{CieIlluminant, Planck}, lab::CieLab, rgb::RgbSpace, spectrum::{to_wavelength, Spectrum, NS, SPECTRUM_WAVELENGTH_RANGE}, traits::{Filter, Light}, xyz::{RelXYZ, XYZ}
+    cam::{CieCam02, CieCam16, ViewConditions},
+    error::Error,
+    illuminant::{CieIlluminant, Planck},
+    lab::CieLab,
+    rgb::RgbSpace,
+    spectrum::{to_wavelength, Spectrum, NS, SPECTRUM_WAVELENGTH_RANGE},
+    traits::{Filter, Light},
+    xyz::{RelXYZ, XYZ},
 };
 use nalgebra::{Matrix3, SMatrix, Vector3};
 use std::{fmt, ops::RangeInclusive, sync::OnceLock};
@@ -289,7 +296,7 @@ impl Observer {
 
     pub fn spectral_locus_rxyzs(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
         let xyzn = self.xyz_from_spectrum(ref_white.illuminant().as_ref());
-        let scale = 100.0 * self.data().lumconst  / xyzn.y();
+        let scale = 100.0 * self.data().lumconst / xyzn.y();
         let mut obs = self.data().data.clone();
         let white = &ref_white.illuminant().as_ref().0;
         for r in 0..3 {
@@ -298,7 +305,7 @@ impl Observer {
             }
         }
         let mut v = Vec::with_capacity(NS);
-        for  w in SPECTRUM_WAVELENGTH_RANGE {
+        for w in SPECTRUM_WAVELENGTH_RANGE {
             let xyz = obs.column(w - SPECTRUM_WAVELENGTH_RANGE.start()).into();
             let rxyz = RelXYZ::from_vec(xyz, xyzn.set_illuminance(100.0));
             v.push((w, rxyz));
@@ -309,10 +316,12 @@ impl Observer {
     pub fn santized_spectral_locus_rxyz(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
         let sl_full = self.spectral_locus_rxyzs(ref_white);
         let valid_range = self.spectral_locus_wavelength_range();
-        sl_full.into_iter().filter(|(w,_)|valid_range.contains(w))
-            .collect()  
+        sl_full
+            .into_iter()
+            .filter(|(w, _)| valid_range.contains(w))
+            .collect()
     }
-    
+
     /// Tristimulus values for the Standard Illuminants in this library.
     ///
     /// Values are not normalized by default, unless an illuminance value is provided.
@@ -696,9 +705,9 @@ mod obs_test {
 
     #[test]
     fn test_spectral_locus_rel_xyz() {
-        use crate::observer::Observer::Cie1931;
-        use crate::illuminant::CieIlluminant;
         use crate::cam::CamTransforms;
+        use crate::illuminant::CieIlluminant;
+        use crate::observer::Observer::Cie1931;
 
         let sl = Cie1931.spectral_locus_rxyzs(CieIlluminant::D65);
         for (w, rxyz) in sl {
@@ -706,6 +715,5 @@ mod obs_test {
             let [x, y, z] = rxyz.xyz().values();
             println!("{w}, {x:.5}, {y:.5}, {z:.5}, {j:.1}, {c:.1}, {h:.1}");
         }
-
     }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -294,7 +294,7 @@ impl Observer {
         Ok(XYZ::from_vecs(Vector3::new(x, y, z), self.data().tag))
     }
 
-    pub fn spectral_locus_rxyzs(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
+    pub fn spectral_loci(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
         let xyzn = self.xyz_from_spectrum(ref_white.illuminant().as_ref());
         let scale = 100.0 * self.data().lumconst / xyzn.y();
         let mut obs = self.data().data.clone();
@@ -313,8 +313,8 @@ impl Observer {
         v
     }
 
-    pub fn santized_spectral_locus_rxyz(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
-        let sl_full = self.spectral_locus_rxyzs(ref_white);
+    pub fn trimmed_spectral_loci(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
+        let sl_full = self.spectral_loci(ref_white);
         let valid_range = self.spectral_locus_wavelength_range();
         sl_full
             .into_iter()
@@ -709,11 +709,11 @@ mod obs_test {
         use crate::illuminant::CieIlluminant;
         use crate::observer::Observer::Cie1931;
 
-        let sl = Cie1931.spectral_locus_rxyzs(CieIlluminant::D65);
+        let sl = Cie1931.spectral_loci(CieIlluminant::D65);
         for (w, rxyz) in sl {
             let [j, c, h] = CieCam16::from_xyz(rxyz, CIE248_HOME_SCREEN).jch();
             let [x, y, z] = rxyz.xyz().values();
-            println!("{w}, {x:.5}, {y:.5}, {z:.5}, {j:.1}, {c:.1}, {h:.1}");
+            println!("{w}, {x:.8}, {y:.8}, {z:.8}, {j:.3}, {c:.4}, {h:.5}");
         }
     }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -294,33 +294,35 @@ impl Observer {
         Ok(XYZ::from_vecs(Vector3::new(x, y, z), self.data().tag))
     }
 
-    pub fn spectral_loci(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
+    /*
+    pub fn spectral_locus(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
         let xyzn = self.xyz_from_spectrum(ref_white.illuminant().as_ref());
-        let scale = 100.0 * self.data().lumconst / xyzn.y();
         let mut obs = self.data().data;
         let white = &ref_white.illuminant().as_ref().0;
         for r in 0..3 {
             for c in 0..NS {
-                obs[(r, c)] *= white[c] * scale;
+                obs[(r, c)] *= white[c] * self.data().lumconst;
             }
         }
         let mut v = Vec::with_capacity(NS);
         for w in SPECTRUM_WAVELENGTH_RANGE {
             let xyz = obs.column(w - SPECTRUM_WAVELENGTH_RANGE.start()).into();
-            let rxyz = RelXYZ::from_vec(xyz, xyzn.set_illuminance(100.0));
+            let rxyz = RelXYZ::from_vec(xyz, xyzn);
             v.push((w, rxyz));
+            dbg!(&v.last());
         }
         v
     }
 
-    pub fn trimmed_spectral_loci(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
-        let sl_full = self.spectral_loci(ref_white);
+    pub fn trimmed_spectral_locus(&self, ref_white: CieIlluminant) -> Vec<(usize, RelXYZ)> {
+        let sl_full = self.spectral_locus(ref_white);
         let valid_range = self.spectral_locus_wavelength_range();
         sl_full
             .into_iter()
             .filter(|(w, _)| valid_range.contains(w))
             .collect()
     }
+     */
 
     /// Tristimulus values for the Standard Illuminants in this library.
     ///
@@ -505,7 +507,6 @@ mod obs_test {
     #[cfg(feature = "supplemental-observers")]
     use super::Observer::Cie1964;
     use super::{Observer, Observer::Cie1931};
-    use crate::cam::{CieCam16, CIE248_HOME_SCREEN};
     use crate::illuminant::CieIlluminant;
     use crate::rgb::RgbSpace;
     use crate::spectrum::SPECTRUM_WAVELENGTH_RANGE;
@@ -703,17 +704,35 @@ mod obs_test {
         );
     }
 
+    /*
     #[test]
-    fn test_spectral_locus_rel_xyz() {
+    fn test_spectral_locus() {
         use crate::cam::CamTransforms;
         use crate::illuminant::CieIlluminant;
         use crate::observer::Observer::Cie1931;
 
-        let sl = Cie1931.spectral_loci(CieIlluminant::D65);
+        let sl = Cie1931.spectral_locus(CieIlluminant::D65);
         for (w, rxyz) in sl {
             let [j, c, h] = CieCam16::from_xyz(rxyz, CIE248_HOME_SCREEN).jch();
             let [x, y, z] = rxyz.xyz().values();
             println!("{w}, {x:.8}, {y:.8}, {z:.8}, {j:.3}, {c:.4}, {h:.5}");
         }
     }
+
+    #[test]
+    fn test_spectral_locus_round_trip() {
+        use crate::cam::CamTransforms;
+        use crate::illuminant::CieIlluminant;
+        use crate::observer::Observer::Cie1931;
+
+        let sl = Cie1931.spectral_locus(CieIlluminant::D65);
+        for (w, rxyz) in sl {
+            let cam =  CieCam16::from_xyz(rxyz, CIE248_HOME_SCREEN);
+            let bxyz = cam.xyz(None, Some(CIE248_HOME_SCREEN)).unwrap();
+            let [rx, ry, rz] = rxyz.xyz().values();
+            let [bx, by, bz] = bxyz.xyz().values();
+            println!("{w}, {rx:.8}, {ry:.8}, {rz:.8}, {bx:.8}, {by:.8}, {bz:.8}");
+        }
+    }
+     */
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -165,7 +165,7 @@ impl Observer {
         let xyz = self.xyz_from_spectrum(&s);
         let scale = 100.0 / xyzn.xyz.y;
         // unwrap OK as we are using only one observer (self) here
-        RelXYZ::new(xyz*scale, xyzn*scale).unwrap()
+        RelXYZ::from_xyz(xyz*scale, xyzn*scale).unwrap()
     }
 
     /*

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -53,7 +53,7 @@ use crate::{
     rgb::RgbSpace,
     spectrum::{to_wavelength, Spectrum, NS, SPECTRUM_WAVELENGTH_RANGE},
     traits::{Filter, Light},
-    xyz::XYZ,
+    xyz::{RelXYZ, XYZ},
 };
 use nalgebra::{Matrix3, SMatrix, Vector3};
 use std::{fmt, ops::RangeInclusive, sync::OnceLock};
@@ -159,6 +159,16 @@ impl Observer {
         self.data().name
     }
 
+    pub fn rel_xyz(&self, light: &dyn Light, filter: &dyn Filter) -> RelXYZ {
+        let xyzn = self.xyz_from_spectrum(&light.spectrum());
+        let s = *light.spectrum() * *filter.spectrum();
+        let xyz = self.xyz_from_spectrum(&s);
+        let scale = 100.0 / xyzn.xyz.y;
+        // unwrap OK as we are using only one observer (self) here
+        RelXYZ::new(xyz*scale, xyzn*scale).unwrap()
+    }
+
+    /*
     fn xyz_and_xyzn(&self, light: &dyn Light, filter: &dyn Filter) -> [XYZ; 2] {
         let xyzn = light.xyzn(self.data().tag, None);
         let s = *light.spectrum() * *filter.spectrum();
@@ -166,6 +176,7 @@ impl Observer {
         let scale = 100.0 / xyzn.xyz.y;
         [xyz * scale, xyzn * scale]
     }
+     */
 
     /// Calulates Tristimulus values for an object implementing the [Light] trait, and an optional [Filter],
     /// filtering the light.
@@ -200,9 +211,9 @@ impl Observer {
     /// # Returns
     /// * `CieLab` - The computed CIELAB color representation for the light and filter combination.
     pub fn lab(&self, light: &dyn Light, filter: &dyn Filter) -> CieLab {
-        let [xyz, xyzn] = self.xyz_and_xyzn(light, filter);
+        let rxyz = self.rel_xyz(light, filter);
         // unwrap OK as we are using only one observer (self) here
-        CieLab::from_xyz(xyz, xyzn).unwrap()
+        CieLab::from_xyz(rxyz)
     }
 
     /// Calculates the L*a*b* CIELAB D65 values of a Colorant, using D65 as an illuminant.
@@ -228,9 +239,9 @@ impl Observer {
     /// # Returns
     /// * `CieCam16` - The computed CIECAM16 color appearance model representation for the light and filter combination.
     pub fn ciecam16(&self, light: &dyn Light, filter: &dyn Filter, vc: ViewConditions) -> CieCam16 {
-        let [xyz, xyzn] = self.xyz_and_xyzn(light, filter);
+        let rxyz = self.rel_xyz(light, filter);
         // unwrap OK as we are using only one observer (self) here
-        CieCam16::from_xyz(xyz, xyzn, vc).unwrap()
+        CieCam16::from_xyz(rxyz, vc)
     }
 
     /// Calculates the CIECAM02 color appearance model values for a light source and filter combination.
@@ -244,9 +255,9 @@ impl Observer {
     /// # Returns
     /// * `CieCam02` - The computed CIECAM02 color appearance model representation for the light and filter combination.
     pub fn ciecam02(&self, light: &dyn Light, filter: &dyn Filter, vc: ViewConditions) -> CieCam02 {
-        let [xyz, xyzn] = self.xyz_and_xyzn(light, filter);
+        let rxyz = self.rel_xyz(light, filter);
         // unwrap OK as we are using only one observer (self) here
-        CieCam02::from_xyz(xyz, xyzn, vc).unwrap()
+        CieCam02::from_xyz(rxyz, vc)
     }
 
     /// Calculates Tristimulus valus, in form of an [XYZ] object of a general spectrum.
@@ -472,6 +483,19 @@ mod obs_test {
     use crate::xyz::XYZ;
     use approx::assert_ulps_eq;
     use strum::IntoEnumIterator as _;
+
+    #[test]
+    fn test_rel_xyz() {
+        use crate::colorant::Colorant;
+
+        let obs = Cie1931;
+        let light = CieIlluminant::D65;
+        let filter = Colorant::gray(0.5);
+
+        let rxyz= obs.rel_xyz(&light, &filter);
+        assert_ulps_eq!(rxyz.xyz()*2.0, rxyz.white_point(),epsilon = 1E-5);
+        assert_ulps_eq!(rxyz.white_point(), obs.xyz_d65(), epsilon = 1E-5);
+    }
 
     #[test]
     fn test_cie1931_spectral_locus_min_max() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,4 +41,4 @@ pub use super::rgb::{Rgb, RgbSpace, WideRgb};
 pub use super::spectrum::Spectrum;
 pub use super::stimulus::Stimulus;
 pub use super::traits::{Filter, Light};
-pub use super::xyz::{Chromaticity, XYZ};
+pub use super::xyz::{Chromaticity, XYZ, RelXYZ};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,4 +41,4 @@ pub use super::rgb::{Rgb, RgbSpace, WideRgb};
 pub use super::spectrum::Spectrum;
 pub use super::stimulus::Stimulus;
 pub use super::traits::{Filter, Light};
-pub use super::xyz::{Chromaticity, XYZ, RelXYZ};
+pub use super::xyz::{Chromaticity, RelXYZ, XYZ};

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -36,6 +36,9 @@ mod chromaticity;
 mod dominant;
 pub use chromaticity::Chromaticity;
 
+mod rel_xyz;
+pub use rel_xyz::RelXYZ;
+
 use core::f64;
 
 use crate::{error::Error, observer::Observer, rgb::RgbSpace, rgb::WideRgb};

--- a/src/xyz/rel_xyz.rs
+++ b/src/xyz/rel_xyz.rs
@@ -1,0 +1,69 @@
+use approx::AbsDiffEq;
+
+use super::XYZ;
+
+/// # Related Tristimulus Values
+/// 
+/// Tristimulus Values for a given sample and reference white,
+/// used to represent related colors as used in various color
+/// models. Typically the reference white is normalized to have
+/// an Y-value of 100 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub struct RelXYZ {
+    related: XYZ,
+    white_point: XYZ,
+}
+
+impl RelXYZ {
+    pub fn new(sample: XYZ, refwhite: XYZ) -> Result<Self, crate::Error> {
+        if sample.observer != refwhite.observer {
+            Err(crate::Error::RequireSameObserver)
+        } else {
+            Ok(RelXYZ { related: sample, white_point: refwhite })
+        }
+    }
+
+    pub fn with_d65(related: XYZ) -> Self {
+        let white_point = related.observer.xyz_d65();
+        RelXYZ {
+            related,
+            white_point,    
+        }
+    }
+
+    pub fn with_d50(related: XYZ) -> Self {
+        let white_point = related.observer.xyz_d50();
+        RelXYZ {
+            related,
+            white_point,    
+        }
+    }
+
+    pub fn xyz(&self) -> XYZ {
+        self.related
+    }
+
+    pub fn white_point(&self) -> XYZ {
+        self.white_point
+    }
+
+    pub fn values(&self) -> [[f64; 3];2] {
+        [self.related.values(), self.white_point.values()]
+    }
+}
+
+impl AbsDiffEq for RelXYZ {
+    type Epsilon = f64;
+
+    fn default_epsilon() -> Self::Epsilon {
+        f64::default_epsilon()
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        let xyz_eq = self.related.abs_diff_eq(&other.related, epsilon);
+        let xyzn_eq = self.white_point.abs_diff_eq(&other.white_point, epsilon);
+        let obs_eq = self.related.observer == other.related.observer;
+        xyz_eq && xyzn_eq && obs_eq
+    }
+}

--- a/src/xyz/rel_xyz.rs
+++ b/src/xyz/rel_xyz.rs
@@ -31,6 +31,20 @@ impl RelXYZ {
         }
     }
 
+    /// Creates a new `RelXYZ` instance with the given XYZ values and white point.
+    /// # Arguments
+    /// - `xyz`: A 3-element vector representing the XYZ tristimulus values.
+    /// - `white_point`: The reference white point as an `XYZ` instance.
+    ///
+    /// # Returns
+    /// A new `RelXYZ` instance initialized with the provided XYZ values and white point.   
+    pub fn from_vec(xyz: Vector3<f64>, white_point: XYZ) -> Self {
+        RelXYZ {
+            xyz,
+            white_point,
+        }
+    }
+
     /// Creates a new `RelXYZ` instance from an `XYZ` instance and a reference white point.
     ///
     /// - `xyz`: An `XYZ` instance representing the color to be transformed.
@@ -95,6 +109,8 @@ impl RelXYZ {
     pub fn values(&self) -> [[f64; 3]; 2] {
         [self.xyz.into(), self.white_point.xyz.into()]
     }
+
+
 }
 
 impl AbsDiffEq for RelXYZ {

--- a/src/xyz/rel_xyz.rs
+++ b/src/xyz/rel_xyz.rs
@@ -4,11 +4,11 @@ use nalgebra::Vector3;
 use super::XYZ;
 
 /// # Related Tristimulus Values
-/// 
+///
 /// Tristimulus Values for a given sample and reference white,
 /// used to represent related colors as used in various color
 /// models. Typically the reference white is normalized to have
-/// an Y-value of 100 
+/// an Y-value of 100
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct RelXYZ {
@@ -24,8 +24,11 @@ impl RelXYZ {
     ///
     /// # Returns
     /// A new `RelXYZ` instance initialized with the provided XYZ values and white point.   
-    pub fn new(xyz: [f64;3], white_point: XYZ) -> Self {
-        RelXYZ { xyz: xyz.into(), white_point }
+    pub fn new(xyz: [f64; 3], white_point: XYZ) -> Self {
+        RelXYZ {
+            xyz: xyz.into(),
+            white_point,
+        }
     }
 
     /// Creates a new `RelXYZ` instance from an `XYZ` instance and a reference white point.
@@ -41,7 +44,10 @@ impl RelXYZ {
         if xyz.observer != white_point.observer {
             Err(crate::Error::RequireSameObserver)
         } else {
-            Ok(RelXYZ { xyz: xyz.xyz, white_point })
+            Ok(RelXYZ {
+                xyz: xyz.xyz,
+                white_point,
+            })
         }
     }
 
@@ -55,7 +61,7 @@ impl RelXYZ {
         let white_point = xyz.observer.xyz_d65();
         RelXYZ {
             xyz: xyz.xyz,
-            white_point,    
+            white_point,
         }
     }
 
@@ -69,7 +75,7 @@ impl RelXYZ {
         let white_point = xyz.observer.xyz_d50();
         RelXYZ {
             xyz: xyz.xyz,
-            white_point,    
+            white_point,
         }
     }
 
@@ -87,10 +93,7 @@ impl RelXYZ {
     ///
     /// The first row contains the XYZ values of the color, and the second row contains the XYZ values of the reference white point.        
     pub fn values(&self) -> [[f64; 3]; 2] {
-        [
-            self.xyz.into(),
-            self.white_point.xyz.into(),
-        ]
+        [self.xyz.into(), self.white_point.xyz.into()]
     }
 }
 

--- a/src/xyz/rel_xyz.rs
+++ b/src/xyz/rel_xyz.rs
@@ -39,10 +39,7 @@ impl RelXYZ {
     /// # Returns
     /// A new `RelXYZ` instance initialized with the provided XYZ values and white point.   
     pub fn from_vec(xyz: Vector3<f64>, white_point: XYZ) -> Self {
-        RelXYZ {
-            xyz,
-            white_point,
-        }
+        RelXYZ { xyz, white_point }
     }
 
     /// Creates a new `RelXYZ` instance from an `XYZ` instance and a reference white point.
@@ -109,8 +106,6 @@ impl RelXYZ {
     pub fn values(&self) -> [[f64; 3]; 2] {
         [self.xyz.into(), self.white_point.xyz.into()]
     }
-
-
 }
 
 impl AbsDiffEq for RelXYZ {

--- a/src/xyz/rel_xyz.rs
+++ b/src/xyz/rel_xyz.rs
@@ -17,18 +17,40 @@ pub struct RelXYZ {
 }
 
 impl RelXYZ {
+    /// Creates a new `RelXYZ` instance with the given XYZ values and white point.
+    /// # Arguments
+    /// - `xyz`: A 3-element array representing the XYZ tristimulus values.
+    /// - `white_point`: The reference white point as an `XYZ` instance.
+    ///
+    /// # Returns
+    /// A new `RelXYZ` instance initialized with the provided XYZ values and white point.   
     pub fn new(xyz: [f64;3], white_point: XYZ) -> Self {
         RelXYZ { xyz: xyz.into(), white_point }
     }
 
-    pub fn from_xyz(sample: XYZ, refwhite: XYZ) -> Result<Self, crate::Error> {
-        if sample.observer != refwhite.observer {
+    /// Creates a new `RelXYZ` instance from an `XYZ` instance and a reference white point.
+    ///
+    /// - `xyz`: An `XYZ` instance representing the color to be transformed.
+    /// - `white_point`: An `XYZ` instance representing the reference white point.
+    ///
+    /// # Returns
+    /// A new `RelXYZ` instance initialized with the XYZ values from the provided `XYZ` instance and the reference white point.
+    /// # Errors
+    /// Returns an error if the observer of the `xyz` and `white_point` do not match.   
+    pub fn from_xyz(xyz: XYZ, white_point: XYZ) -> Result<Self, crate::Error> {
+        if xyz.observer != white_point.observer {
             Err(crate::Error::RequireSameObserver)
         } else {
-            Ok(RelXYZ { xyz: sample.xyz, white_point: refwhite })
+            Ok(RelXYZ { xyz: xyz.xyz, white_point })
         }
     }
 
+    /// Creates a new `RelXYZ` instance with the given XYZ values and a D65 white point.
+    /// # Arguments
+    /// - `xyz`: a XYZ tristimulus value.
+    ///
+    /// # Returns
+    /// A new `RelXYZ` instance initialized with the provided XYZ value and a D65 white point.
     pub fn with_d65(xyz: XYZ) -> Self {
         let white_point = xyz.observer.xyz_d65();
         RelXYZ {
@@ -37,6 +59,12 @@ impl RelXYZ {
         }
     }
 
+    /// Creates a new `RelXYZ` instance with the given XYZ values and a D50 white point.
+    /// # Arguments
+    /// - `xyz`: a XYZ tristimulus value.
+    ///
+    /// # Returns
+    /// A new `RelXYZ` instance initialized with the provided XYZ value and a D50 white point.
     pub fn with_d50(xyz: XYZ) -> Self {
         let white_point = xyz.observer.xyz_d50();
         RelXYZ {
@@ -45,14 +73,19 @@ impl RelXYZ {
         }
     }
 
+    /// Returns the XYZ tristimulus values of the color represented by this `RelXYZ` instance.
     pub fn xyz(&self) -> XYZ {
         XYZ::from_vecs(self.xyz, self.white_point.observer)
     }
 
+    /// Returns the reference white point of this `RelXYZ` instance.
     pub fn white_point(&self) -> XYZ {
         self.white_point
     }
 
+    /// Returns the XYZ tristimulus values of the color and the reference white point as a 2D array.
+    ///
+    /// The first row contains the XYZ values of the color, and the second row contains the XYZ values of the reference white point.        
     pub fn values(&self) -> [[f64; 3]; 2] {
         [
             self.xyz.into(),


### PR DESCRIPTION
## Summary

Inspired by #91, and previous discussions on the XYZ type,  this PR introduces a **`RelXYZ`**, to represent _related_ tristimulus values— XYZ values with a common white adaptation state, represented by a white point's tristimulus. In contrast, the existing **`XYZ`** type will continue to represent _unrelated_ tristimulus values (typically direct light sources or illuminants).

## Motivation

- In CIE terminology, “related colors” are the foundation for all higher-level color-appearance and adaptation models.  
- By modeling related tristimulus values explicitly, we align our data structures more closely with CIECAM and other perceptual workflows.  
- Clarifies intent:  
  - `XYZ` → raw, _unrelated_ tristimulus (e.g., illuminant or source)  
  - `RelXYZ` → _related_ tristimulus (surface under adapted white point, or pixels in a display)

##  Backward-Compatibility

- `XYZ` remains unchanged, aside from clarified documentation.  
- No public APIs are removed; all existing `XYZ` methods continue to work as before.
