### PR TITLE
Suggestion on refactoring of `Illuminant::cfi_reference`

### DIFF
--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -147,18 +147,21 @@ impl Illuminant {
         // crossover.
         const BLEND_RANGE_START: f64 = 4000.0;
         const BLEND_RANGE_END: f64 = 5000.0;
-        match cct {
-            c if c < BLEND_RANGE_START => Ok(Self::planckian(c)),
-            c if c > BLEND_RANGE_END => Ok(Self::d_illuminant(c)?),
-            _ => {
-                let illuminant_planckian = Self::planckian(BLEND_RANGE_START);
-                let illuminant_d = Self::d_illuminant(BLEND_RANGE_END)?;
-                let ratio_d = (cct - BLEND_RANGE_START) / (BLEND_RANGE_END - BLEND_RANGE_START);
-                let ratio_planckian = 1.0 - ratio_d;
-                Ok(Self(
-                    ratio_d * illuminant_d.0 + ratio_planckian * illuminant_planckian.0,
-                ))
-            }
+
+        if cct < BLEND_RANGE_START {
+            Ok(Self::planckian(cct))
+        } else if cct > BLEND_RANGE_END {
+            Self::d_illuminant(cct)
+        } else {
+            let illuminant_planckian = Self::planckian(BLEND_RANGE_START);
+            let illuminant_d = Self::d_illuminant(BLEND_RANGE_END)?;
+
+            let ratio_d = (cct - BLEND_RANGE_START) / (BLEND_RANGE_END - BLEND_RANGE_START);
+            let ratio_planckian = 1.0 - ratio_d;
+
+            Ok(Self(
+                ratio_d * illuminant_d.0 + ratio_planckian * illuminant_planckian.0,
+            ))
         }
     }
 

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -138,13 +138,15 @@ impl Illuminant {
         Self(Spectrum(data))
     }
 
-    // TODO: Add documentation on what this is for. Which standard it is implemented
-    // according to.
+    /// Returns the reference illuminant for a test source with the given correlated color
+    /// temperature (CCT) as defined by the TM-30-20 standard.
+    ///
+    /// The reference illuminant varies with the correlated color temperature (CCT)
+    /// of the illuminant being tested. For a CCT below 4000 K, a blackbody Planckian
+    /// illuminant is returned. For a CCT above 5000 K, a CIE D illuminant is returned.
+    /// For CCTs between 4000 K and 5000 K, the two illuminants are blended to create a
+    /// smooth crossover.
     pub fn cfi_reference(cct: f64) -> Result<Self, crate::Error> {
-        // Below this range, a blackbody planckian illuminant is returned.
-        // Above this range, a daylight (CIE D series) illuminant is returned.
-        // In this range, the two illuminants above are blended to create a smooth
-        // crossover.
         const BLEND_RANGE_START: f64 = 4000.0;
         const BLEND_RANGE_END: f64 = 5000.0;
 


### PR DESCRIPTION
I'm trying to understand TM-30 and the components it involves. This lead me to the `Illuminant::cfi_reference` method. It had a lot of repeated constants. So I tried to "clean" that up to see if it would improve the code readability or not. I think this is a slight improvement.

I personally don't really see the benefit of a match statement, if no arm is actually _matching_ against anything, but rather just binds the value and performs a conditional `if` on it.

According to what standard is this method implemented? I do not have access to the paywalled standard documents. So I'm mostly trying to learn from what is available on the open web. The following youtube video seem to do two things differently here. So I'd like to ask if that's from a different standard, or if the video is simply wrong: https://youtu.be/FusjTFYQb6Q?feature=shared&t=135

1. The CCT span where the planckian/D series illuminants are blended are between 4500 K and 5500 K (in contrast to 4000 - 5000 in the current impl)
2. The blending seems to be done differencly. Where the blend edge values are not simply used for the blending. But the illustration hints at that the prominent illuminant is not fixed at the edge value, but rather changes. Meaning to get the CFI reference for 5200 K you would take the D illuminant for CCT=5200K and blend it with the planckian illuminant for 5000K. Is this illustration just a simplification, and the actual standard says something else?

PLEASE NOTE: This PR still has `TODO`s in it. Things I'm not able to answer myself right now. But with your help I'd like to fill in these missing details.