### PR TITLE
Improve CFI color patch discoverability

### DIFF
--- a/src/colorant/ces_data.rs
+++ b/src/colorant/ces_data.rs
@@ -6,11 +6,12 @@ use crate::{
 };
 use std::sync::LazyLock;
 
-/// Create Array of Color Fidelity Index Test Spectra, as used to assess the color fidelity index of a light source.
+/// An array of Color Fidelity Index Test Spectra, as used to assess the color fidelity index of a
+/// light source.
 ///
-/// The data for these is obtained from the <https:://cie.co.at> site's dataset library, on May 29, 2025.
-/// The dataset uses a 380-780-5nm domain, included below in the 'CFI5' static matrix.
-/// Here the dataset is converted to an array of 99 Spectra, using linear interpolation.
+/// The data for these is obtained from the <https://cie.co.at> site's dataset library, on May 29, 2025.
+/// The dataset uses a 380-780-5nm domain. Here the dataset is converted to an array of 99 Spectra,
+/// using linear interpolation.
 pub static CES: LazyLock<Box<[Colorant; N_CFI]>> = LazyLock::new(|| {
     let s_vec: Vec<Colorant> = CES5
         .column_iter()

--- a/src/illuminant/cfi.rs
+++ b/src/illuminant/cfi.rs
@@ -80,7 +80,7 @@ impl CFI {
     ///
     /// # Returns
     /// An array of 99 `f64` values. Each value represents the fidelity score (Rf,i) for the corresponding
-    /// CES under the current light source compared to the reference illuminant (daylight or Planckian).
+    /// [`CES`] under the current light source compared to the reference illuminant (daylight or Planckian).
     /// Higher values indicate better color fidelity for that sample.
     ///
     /// # Usage


### PR DESCRIPTION
I made sure the reference to `CES` was made into a clickable link. Thereby improving the discoverability of the colorants used by CFI.

I also updated the docs on the `CES` constant a bit. One thing I removed was references to a private constant that public users cannot use anyway. I also reworded it to talk about what it contains instead of that it "creates" something. I also fixed the broken link (`http:://` had two colons).