### PR TITLE
Rename "values" array methods to "to_array"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 * Remove undocumented `XYZ::srgb` method that both clamped out-of-gamut values and converted
   directly to a gamma encoded `[u8; 3]`. Obtain the same result with the more explicit
-  `xyz.rgb(Some(RgbSpace::SRGB)).clamp().values()`.
+  `xyz.rgb(Some(RgbSpace::SRGB)).clamp().to_array()`.
 * Remove conversion directly from `WideRgb` to clamped and gamma encoded `[u8; 3]`.
   Prefer being more explicit by converting to the `Rgb` type in between with one of the provided conversion methods.
 * Remove `DeRef<Spectrum> for Illuminant` to be replaced with the more explcicit `AsRef<Spectrum>`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This example calculates the XYZ tristimulus values of the D65 illuminant for bot
   // D65 Tristimulus values, using the CIE1931 standard observer by default
   let xyz_d65 = D65.xyz(None).set_illuminance(100.0);
 
-  let [x, y, z] = xyz_d65.values();
+  let [x, y, z] = xyz_d65.to_array();
   // [95.04, 100.0, 108.86]
 
   // D65 Tristimulus values using the CIE2015 10º observer
@@ -45,7 +45,7 @@ This example calculates the XYZ tristimulus values of the D65 illuminant for bot
   let xyz_d65_10 = D65
     .xyz(Some(Cie2015_10)).set_illuminance(100.0);
 
-  let [x_10, y_10, z_10] = xyz_d65_10.values();
+  let [x_10, y_10, z_10] = xyz_d65_10.to_array();
   //[94.72, 100.0, 107.143]
 ```
 
@@ -65,7 +65,7 @@ locus, often referred to as the tint.
 
   // Calculate CCT and Duv for the A illuminant
   // Requires `cct`, and `cie-illuminants` features
-  let [cct, duv] = A.cct().unwrap().values();
+  let [cct, duv] = A.cct().unwrap().to_array();
   // [2855.4977, 0.0]
 ```
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -51,14 +51,14 @@ pub fn colorvalue(file: String, illuminant: String, format: String) -> Result<()
 fn print_yxy(illuminant: &CieIlluminant, colorant: &Colorant) {
     let xyz = Observer::Cie1931.rel_xyz(illuminant, colorant);
     let (x, y) = xyz.xyz().chromaticity().to_tuple();
-    let [_x, yy, _z] = xyz.xyz().values();
+    let [_x, yy, _z] = xyz.xyz().to_array();
     println!("{}", "Yxy (Y,x,y) chromaticity values".bold());
     println!("{yy:.2}\t{x:.4}\t{y:.4}");
 }
 
 fn print_xyz(illuminant: &CieIlluminant, colorant: &Colorant) {
     let xyz = Observer::Cie1931.rel_xyz(illuminant, colorant);
-    let [x, y, z] = xyz.xyz().values();
+    let [x, y, z] = xyz.xyz().to_array();
     println!("{}", "YYZ (X,Y,Z) Tristimulus Values".bold());
     println!("{x:.2}\t{y:.2}\t{z:.2}");
 }

--- a/plot/src/chart/chromaticity/xy.rs
+++ b/plot/src/chart/chromaticity/xy.rs
@@ -181,9 +181,9 @@ impl XYChromaticity {
     pub fn planckian_xy_slope_angle(&self, cct: f64) -> ((f64, f64), f64) {
         // Get the XYZ coordinates and their derivatives at the given CCT
         let xyz = self.observer.xyz_planckian_locus(cct);
-        let [x, y, z] = xyz.values();
+        let [x, y, z] = xyz.to_array();
         let nom = x + y + z;
-        let [dxdt, dydt, dzdt] = self.observer.xyz_planckian_locus_slope(cct).values();
+        let [dxdt, dydt, dzdt] = self.observer.xyz_planckian_locus_slope(cct).to_array();
         let dnom_dt = dxdt + dydt + dzdt;
 
         // convert XYZ derivatives to xy derivatives using the quotient rule
@@ -203,9 +203,9 @@ impl XYChromaticity {
         // Get the XYZ coordinates and their derivatives at the given CCT
         let cct_observer = colorimetry::observer::Observer::Cie1931;
         let xyz = cct_observer.xyz_planckian_locus(cct);
-        let [x, y, z] = xyz.values();
+        let [x, y, z] = xyz.to_array();
         let sigma_t = x + 15.0 * y + 3.0 * z;
-        let [dxdt, dydt, dzdt] = cct_observer.xyz_planckian_locus_slope(cct).values();
+        let [dxdt, dydt, dzdt] = cct_observer.xyz_planckian_locus_slope(cct).to_array();
         let dsigma_dt = dxdt + 15.0 * dydt + 3.0 * dzdt;
 
         // convert XYZ derivatives to xy derivatives using the quotient rule

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -208,7 +208,7 @@ fn test_colorant_cielab() {
     // A white surface has CIELAB values of L* = 100, a* = 0, b* = 0.
     use approx::assert_abs_diff_eq;
     let colorant = Colorant::white();
-    let [l, a, b] = colorant.cielab(None, None).values();
+    let [l, a, b] = colorant.cielab(None, None).to_array();
     assert_abs_diff_eq!(l, 100.0, epsilon = 1E-4); // L* should be 100 for white
     assert_abs_diff_eq!(a, 0.0, epsilon = 1E-4); // a* should be 0 for white
     assert_abs_diff_eq!(b, 0.0, epsilon = 1E-4); // b* should be 0 for white

--- a/src/colorant.rs
+++ b/src/colorant.rs
@@ -107,7 +107,7 @@ impl Colorant {
     ///
     /// - CmtError::OutOfRange when the spectrum contains values outside the range 0.0 to 1.0.
     pub fn new(spectrum: Spectrum) -> Result<Self, Error> {
-        if spectrum.values().iter().any(|v| !(0.0..=1.0).contains(v)) {
+        if spectrum.as_array().iter().any(|v| !(0.0..=1.0).contains(v)) {
             Err(Error::OutOfRange {
                 name: "Colorant Spectral Value".into(),
                 low: 0.0,

--- a/src/illuminant.rs
+++ b/src/illuminant.rs
@@ -74,7 +74,7 @@ impl AsRef<Spectrum> for Illuminant {
     ///
     /// let illuminant = Illuminant::d65();
     /// let spectrum: &Spectrum = illuminant.as_ref();
-    /// assert_eq!(spectrum.values().len(), 401);
+    /// assert_eq!(spectrum.as_array().len(), 401);
     /// ```
     fn as_ref(&self) -> &Spectrum {
         &self.0
@@ -364,7 +364,10 @@ fn test_d_illuminant_range_error() {
 
 #[test]
 fn test_xyz() {
-    let s = *Illuminant::d_illuminant(6504.0).unwrap().as_ref().values();
+    let s = *Illuminant::d_illuminant(6504.0)
+        .unwrap()
+        .as_ref()
+        .as_array();
     let illuminant = Illuminant(Spectrum::from(s));
     let xyz = illuminant.xyz(None).set_illuminance(100.0);
     approx::assert_ulps_eq!(xyz, Observer::Cie1931.xyz_d65(), epsilon = 2E-2);

--- a/src/illuminant/cct.rs
+++ b/src/illuminant/cct.rs
@@ -154,7 +154,7 @@ impl CCT {
 
     /// Get the CCT as an array of two values: the CCT in Kelvin and the Duv value as
     /// distance to the Planckian Curve in CIE 1960 (u,v) space.
-    pub fn values(&self) -> [f64; 2] {
+    pub fn to_array(&self) -> [f64; 2] {
         [self.0, self.1]
     }
 }
@@ -287,9 +287,9 @@ impl TryFrom<CCT> for XYZ {
 /// ```
 pub fn iso_temp_line(t: f64) -> [f64; 3] {
     let xyz = Cie1931.xyz_planckian_locus(t);
-    let [x, y, z] = xyz.values();
+    let [x, y, z] = xyz.to_array();
     let [u, v] = xyz.uv60();
-    let [dx, dy, dz] = Cie1931.xyz_planckian_locus_slope(t).values();
+    let [dx, dy, dz] = Cie1931.xyz_planckian_locus_slope(t).to_array();
     let sigma = x + 15.0 * y + 3.0 * z;
     let dsigma = dx + 15.0 * dy + 3.0 * dz;
     let den = 6.0 * y * dsigma - 6.0 * dy * sigma; // no need to divide by sigma * sigma, as it would be divided out

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -47,7 +47,7 @@ use crate::{
 /// println!("General CRI Rₐ = {:.1}", ra);
 ///
 /// // All 14 individual Rᵢ values:
-/// let ri_values = cri.values();
+/// let ri_values = cri.to_array();
 /// for (i, &ri) in ri_values.iter().enumerate() {
 ///     println!("R{} = {:.1}", i + 1, ri);
 /// }
@@ -73,7 +73,7 @@ impl CRI {
         self.0.iter().take(8).sum::<f64>() / 8.0
     }
 
-    pub fn values(&self) -> [f64; N_TCS] {
+    pub fn to_array(&self) -> [f64; N_TCS] {
         self.0
     }
 }
@@ -229,7 +229,7 @@ mod cri_test {
         ];
 
         approx::assert_abs_diff_eq!(
-            cri0.values().as_ref(),
+            cri0.to_array().as_ref(),
             expected_values.as_ref(),
             epsilon = 1.0
         );

--- a/src/illuminant/wasm.rs
+++ b/src/illuminant/wasm.rs
@@ -23,7 +23,7 @@ impl Illuminant {
     /// stepsize of 1 nanometer.
     #[wasm_bindgen(js_name=Values)]
     pub fn values_js(&self) -> Box<[f64]> {
-        let values = self.spectrum().values().as_slice().to_vec();
+        let values = self.spectrum().as_array().as_slice().to_vec();
         values.into_boxed_slice()
     }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -15,7 +15,7 @@
 //!   - `CieLab::from_xyz(xyz, white_xyz)` — convert from CIE XYZ under a given white point.  
 //!
 //! - **Accessors**  
-//!   - `.values()` — returns `[L, a, b]`.  
+//!   - `.to_array()` — returns `[L, a, b]`.  
 //!   - AsRef<[f64; 3]> for ergonomic tuple-like access.  
 //!
 //! - **Color‐difference methods**  
@@ -220,7 +220,7 @@ impl CieLab {
     /// Returns the CIE L*a*b* color values as an array of three f64 values.
     /// # Returns
     /// An array containing the L*, a*, and b* values of the color.
-    pub fn values(&self) -> [f64; 3] {
+    pub fn to_array(&self) -> [f64; 3] {
         *self.lab.as_ref()
     }
 
@@ -229,7 +229,7 @@ impl CieLab {
     /// `true` if the L*, a*, and b* values are within valid ranges and
     /// the round-trip conversion to and from XYZ is consistent; `false` otherwise.
     pub fn is_valid(&self) -> bool {
-        let [l, a, b] = self.values();
+        let [l, a, b] = self.to_array();
         if (0.0..=100.0).contains(&l)
             && (-200.0..=200.0).contains(&a)
             && ((-200.0..=200.0).contains(&b))

--- a/src/lab/gamut.rs
+++ b/src/lab/gamut.rs
@@ -62,7 +62,7 @@ impl CieLChGamut {
             // 20 iterations for convergence
             let cielch = CieLCh::new([l, c, h], self.white_point);
             let rgb = cielch.rgb(self.rgb_space);
-            if rgb.values().iter().all(|&v| v < 1.0) {
+            if rgb.to_array().iter().all(|&v| v < 1.0) {
                 c_low = c; // Found a valid chroma, increase lower bound
             } else {
                 c_high = c; // Not in gamut, decrease upper bound
@@ -100,7 +100,7 @@ impl CieLChGamut {
         let cielch = self.max_chroma(l, h)?;
         let rgb = cielch.rgb(self.rgb_space);
         // Check if RGB values are within the gamut explicitly
-        if rgb.values().iter().all(|&v| (0.0..=1.0).contains(&v)) {
+        if rgb.to_array().iter().all(|&v| (0.0..=1.0).contains(&v)) {
             Some(cielch)
         } else {
             None

--- a/src/lab/lch.rs
+++ b/src/lab/lch.rs
@@ -45,7 +45,7 @@ impl CieLCh {
         self.white_point.observer()
     }
 
-    pub fn values(&self) -> [f64; 3] {
+    pub fn to_array(&self) -> [f64; 3] {
         self.lch.into()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ This example calculates the XYZ tristimulus values of the D65 illuminant for bot
   // D65 Tristimulus values, using the CIE1931 standard observer by default
   let xyz_d65 = D65.xyz(None).set_illuminance(100.0);
 
-  let [x, y, z] = xyz_d65.values();
+  let [x, y, z] = xyz_d65.to_array();
   // [95.04, 100.0, 108.86]
 # check!([x, y, z].as_ref(), [95.04, 100.0, 108.86].as_ref(),  epsilon = 5E-3);
 
@@ -45,7 +45,7 @@ This example calculates the XYZ tristimulus values of the D65 illuminant for bot
   let xyz_d65_10 = D65
     .xyz(Some(Cie2015_10)).set_illuminance(100.0);
 
-  let [x_10, y_10, z_10] = xyz_d65_10.values();
+  let [x_10, y_10, z_10] = xyz_d65_10.to_array();
   //[94.72, 100.0, 107.143]
 # check!([x_10, y_10, z_10].as_ref(), [94.72, 100.0, 107.143].as_ref(), epsilon = 5E-3);
 ```
@@ -69,7 +69,7 @@ locus, often referred to as the tint.
   // Calculate CCT and Duv for the A illuminant
   // Requires `cct`, and `cie-illuminants` features
 # #[cfg(all(feature="cct", feature="cie-illuminants"))]
-  let [cct, duv] = A.cct().unwrap().values();
+  let [cct, duv] = A.cct().unwrap().to_array();
 # #[cfg(all(feature="cct", feature="cie-illuminants"))]
 # check!([cct, duv].as_ref(), [2855.4977, 0.0].as_ref(),  epsilon = 5E-4);
   // [2855.4977, 0.0]

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -385,7 +385,7 @@ impl Observer {
             rgbspace
                 .primaries()
                 .iter()
-                .flat_map(|s| self.xyz_from_spectrum(s).set_illuminance(1.0).values()),
+                .flat_map(|s| self.xyz_from_spectrum(s).set_illuminance(1.0).to_array()),
         );
         let xyzw = opt_white
             .unwrap_or(self.xyz(&rgbspace.white(), None))
@@ -418,7 +418,7 @@ impl Observer {
             rgbspace
                 .primaries()
                 .iter()
-                .flat_map(|s| self.xyz_from_spectrum(s).set_illuminance(1.0).values()),
+                .flat_map(|s| self.xyz_from_spectrum(s).set_illuminance(1.0).to_array()),
         );
         let xyzw = self.xyz(&rgbspace.white(), None).set_illuminance(1.0);
         let decomp = rgb2xyz.lu();
@@ -696,14 +696,14 @@ mod obs_test {
     fn test_xyz_d65_d50() {
         let cie1931_d65_xyz = Cie1931.xyz_d65();
         approx::assert_ulps_eq!(
-            cie1931_d65_xyz.values().as_ref(),
+            cie1931_d65_xyz.to_array().as_ref(),
             [95.047, 100.0, 108.883].as_ref(),
             epsilon = 5E-2
         );
 
         let cie1931_d50_xyz = Cie1931.xyz_d50();
         approx::assert_ulps_eq!(
-            cie1931_d50_xyz.values().as_ref(),
+            cie1931_d50_xyz.to_array().as_ref(),
             [96.421, 100.0, 82.519].as_ref(),
             epsilon = 5E-2
         );
@@ -713,14 +713,14 @@ mod obs_test {
     fn test_xyz_d65_d50_cie1964() {
         let cie1964_d50_xyz = Cie1964.xyz_d50();
         approx::assert_ulps_eq!(
-            cie1964_d50_xyz.values().as_ref(),
+            cie1964_d50_xyz.to_array().as_ref(),
             [96.720, 100.0, 81.427].as_ref(),
             epsilon = 5E-2
         );
 
         let cie1964_d65_xyz = Cie1964.xyz_d65();
         approx::assert_ulps_eq!(
-            cie1964_d65_xyz.values().as_ref(),
+            cie1964_d65_xyz.to_array().as_ref(),
             [94.811, 100.0, 107.304].as_ref(),
             epsilon = 5E-2
         );
@@ -735,20 +735,20 @@ mod obs_test {
         // Check the first and last points of the spectral locus
         // Data obtained from spreadsheet using data directly downloaded from cie.co.at
         assert_eq!(sl.len(), 401);
-        let xyz_first = sl[0].1.xyz().values();
+        let xyz_first = sl[0].1.xyz().to_array();
         assert_abs_diff_eq!(
             xyz_first.as_ref(),
             [6.46976E-04, 1.84445E-05, 3.05044E-03].as_ref(),
             epsilon = 1E-5
         );
-        let xyz_last = sl[sl.len() - 1].1.xyz().values();
+        let xyz_last = sl[sl.len() - 1].1.xyz().to_array();
         assert_abs_diff_eq!(
             xyz_last.as_ref(),
             [2.48982E-05, 8.99121E-06, 0.0].as_ref(),
             epsilon = 1E-5
         );
         // 550 nm
-        let xyz_550 = sl[170].1.xyz().values();
+        let xyz_550 = sl[170].1.xyz().to_array();
         assert_abs_diff_eq!(
             xyz_550.as_ref(),
             [0.4268018, 0.9796899, 0.0086158].as_ref(),

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -96,7 +96,7 @@ use std::borrow::Cow;
 ///
 /// // Create an sRGB color with normalized RGB values
 /// let rgb = Rgb::new(0.5, 0.25, 0.75, None, None).unwrap();
-/// assert_abs_diff_eq!(rgb.values().as_ref(), [0.5, 0.25, 0.75].as_ref(), epsilon = 1e-6);
+/// assert_abs_diff_eq!(rgb.to_array().as_ref(), [0.5, 0.25, 0.75].as_ref(), epsilon = 1e-6);
 /// ```
 ///
 /// # Notes
@@ -211,10 +211,10 @@ impl Rgb {
     /// ```rust
     /// # use colorimetry::rgb::Rgb;
     /// let rgb = Rgb::new(0.1, 0.2, 0.3, None, None).unwrap();
-    /// let [r, g, b] = rgb.values();
+    /// let [r, g, b] = rgb.to_array();
     /// assert_eq!([r, g, b], [0.1, 0.2, 0.3]);
     /// ```
-    pub fn values(&self) -> [f64; 3] {
+    pub fn to_array(&self) -> [f64; 3] {
         *self.rgb.as_ref()
     }
 
@@ -338,7 +338,7 @@ impl From<Rgb> for [u8; 3] {
 
 impl From<Rgb> for [f64; 3] {
     fn from(rgb: Rgb) -> Self {
-        rgb.values()
+        rgb.to_array()
     }
 }
 

--- a/src/rgb/widergb.rs
+++ b/src/rgb/widergb.rs
@@ -28,8 +28,8 @@
 //! let compressed_rgb = wide_rgb.compress();
 //! let clamped_rgb = wide_rgb.clamp();
 //!
-//! println!("Compressed: {:?}", compressed_rgb.values());
-//! println!("Clamped: {:?}", clamped_rgb.values());
+//! println!("Compressed: {:?}", compressed_rgb.to_array());
+//! println!("Clamped: {:?}", clamped_rgb.to_array());
 //! ```
 //!
 //! ## Notes
@@ -114,10 +114,10 @@ impl WideRgb {
     /// ```rust
     /// # use colorimetry::rgb::WideRgb;
     /// let rgb = WideRgb::new(0.1, 0.2, 0.3, None, None);
-    /// let [r, g, b] = rgb.values();
+    /// let [r, g, b] = rgb.to_array();
     /// assert_eq!([r, g, b], [0.1, 0.2, 0.3]);
     /// ```
-    pub fn values(&self) -> [f64; 3] {
+    pub fn to_array(&self) -> [f64; 3] {
         *self.rgb.as_ref()
     }
 
@@ -162,7 +162,7 @@ impl WideRgb {
     /// assert!(!out_of_gamut.is_in_gamut());
     /// ```
     pub fn is_in_gamut(&self) -> bool {
-        self.values().iter().all(|v| (0.0..=1.0).contains(v))
+        self.to_array().iter().all(|v| (0.0..=1.0).contains(v))
     }
 
     /// Returns whether or not this Wide RGB instance is within the RGB gamut or not,
@@ -183,7 +183,7 @@ impl WideRgb {
     /// assert!(in_gamut.is_within_gamut(0.01));
     /// ```
     pub fn is_within_gamut(&self, epsilon: f64) -> bool {
-        self.values().iter().all(|&v| v < 1.0 - epsilon)
+        self.to_array().iter().all(|&v| v < 1.0 - epsilon)
     }
 
     pub fn is_black(&self, epsilon: f64) -> bool {
@@ -199,7 +199,7 @@ impl WideRgb {
     ///
     /// let wide_rgb = WideRgb::new(1.0, 0.2, 0.8, None, None);
     /// let rgb = wide_rgb.to_rgb().unwrap();
-    /// assert_eq!(rgb.values(), wide_rgb.values());
+    /// assert_eq!(rgb.to_array(), wide_rgb.to_array());
     ///
     /// // A `WideRgb` value with out-of-gamut components.
     /// let wide_rgb = WideRgb::new(1.2, -0.5, 0.8, None, None);
@@ -228,7 +228,7 @@ impl WideRgb {
     /// // Clamp the values to the [0.0, 1.0] range.
     /// let clamped_rgb = wide_rgb.clamp();
     ///
-    /// assert_eq!(clamped_rgb.values(), [1.0, 0.0, 0.8]);
+    /// assert_eq!(clamped_rgb.to_array(), [1.0, 0.0, 0.8]);
     /// ```
     ///
     /// # Parameters
@@ -270,7 +270,7 @@ impl WideRgb {
     /// // Compresses the values to the [0.0, 1.0] range.
     /// let compressed_rgb = wide_rgb.compress();
     ///
-    /// assert_abs_diff_eq!(compressed_rgb.values().as_ref(), [1.0, 0.0, 0.7647].as_ref(), epsilon = 0.0001);
+    /// assert_abs_diff_eq!(compressed_rgb.to_array().as_ref(), [1.0, 0.0, 0.7647].as_ref(), epsilon = 0.0001);
     /// ```
     ///
     /// # Notes
@@ -303,7 +303,7 @@ impl AsRef<Vector3<f64>> for WideRgb {
 
 impl From<WideRgb> for [f64; 3] {
     fn from(rgb: WideRgb) -> Self {
-        rgb.values()
+        rgb.to_array()
     }
 }
 
@@ -336,7 +336,7 @@ mod rgb_tests {
     #[test]
     fn get_values() {
         let rgb = WideRgb::new(0.1, 0.2, 0.3, None, None);
-        let [r, g, b] = rgb.values();
+        let [r, g, b] = rgb.to_array();
         assert_eq!(r, 0.1);
         assert_eq!(g, 0.2);
         assert_eq!(b, 0.3);
@@ -345,13 +345,13 @@ mod rgb_tests {
         assert_eq!(rgb.g(), 0.2);
         assert_eq!(rgb.b(), 0.3);
 
-        assert_eq!(<[f64; 3]>::from(rgb), rgb.values());
+        assert_eq!(<[f64; 3]>::from(rgb), rgb.to_array());
     }
 
     #[test]
     fn out_of_gamut_values() {
         let rgb = WideRgb::new(-0.8, 2.7, 0.8, None, None);
-        let [r, g, b] = rgb.values();
+        let [r, g, b] = rgb.to_array();
         assert_eq!(r, -0.8);
         assert_eq!(g, 2.7);
         assert_eq!(b, 0.8);
@@ -360,47 +360,47 @@ mod rgb_tests {
     #[test]
     fn compress_in_gamut() {
         let rgb = WideRgb::new(0.0, 0.0, 0.0, None, None).compress();
-        assert_eq!(rgb.values(), [0.0, 0.0, 0.0]);
+        assert_eq!(rgb.to_array(), [0.0, 0.0, 0.0]);
 
         let rgb = WideRgb::new(1.0, 1.0, 1.0, None, None).compress();
-        assert_eq!(rgb.values(), [1.0, 1.0, 1.0]);
+        assert_eq!(rgb.to_array(), [1.0, 1.0, 1.0]);
 
         let rgb = WideRgb::new(0.75, 0.75, 0.75, None, None).compress();
-        assert_eq!(rgb.values(), [0.75, 0.75, 0.75]);
+        assert_eq!(rgb.to_array(), [0.75, 0.75, 0.75]);
 
         let rgb = WideRgb::new(0.1, 0.3, 1.0, None, None).compress();
-        assert_eq!(rgb.values(), [0.1, 0.3, 1.0]);
+        assert_eq!(rgb.to_array(), [0.1, 0.3, 1.0]);
 
         let rgb = WideRgb::new(0.0, 0.3, 1.0, None, None).compress();
-        assert_eq!(rgb.values(), [0.0, 0.3, 1.0]);
+        assert_eq!(rgb.to_array(), [0.0, 0.3, 1.0]);
     }
 
     #[test]
     fn compress_out_of_gamut() {
         // Same value above 1.0 are all scaled down to 1.0
         let rgb = WideRgb::new(1.2, 1.2, 1.2, None, None).compress();
-        assert_eq!(rgb.values(), [1.0, 1.0, 1.0]);
+        assert_eq!(rgb.to_array(), [1.0, 1.0, 1.0]);
 
         // Same value below 0.0 are all scaled up to 0.0
         let rgb = WideRgb::new(-0.5, -0.5, -0.5, None, None).compress();
-        assert_eq!(rgb.values(), [0.0, 0.0, 0.0]);
+        assert_eq!(rgb.to_array(), [0.0, 0.0, 0.0]);
 
         // Different positiv values are all scaled down with the max channel value
         let rgb = WideRgb::new(1.0, 2.0, 3.0, None, None).compress();
-        assert_eq!(rgb.values(), [1.0 / 3.0, 2.0 / 3.0, 1.0]);
+        assert_eq!(rgb.to_array(), [1.0 / 3.0, 2.0 / 3.0, 1.0]);
 
         // Values outside the range both above and below are compressed correctly
         let rgb = WideRgb::new(-0.1, 0.9, 1.1, None, None).compress();
-        assert_eq!(rgb.values(), [0.0, (0.9 + 0.1) / (1.1 + 0.1), 1.0]);
+        assert_eq!(rgb.to_array(), [0.0, (0.9 + 0.1) / (1.1 + 0.1), 1.0]);
 
         // Some negative channel, and some channel that becomes too large after
         // adding the lowest channel to it.
         let rgb = WideRgb::new(-0.5, 0.4, 0.6, None, None).compress();
-        assert_eq!(rgb.values(), [0.0, (0.4 + 0.5) / (0.6 + 0.5), 1.0]);
+        assert_eq!(rgb.to_array(), [0.0, (0.4 + 0.5) / (0.6 + 0.5), 1.0]);
 
         // One negative channel, and the rest stays within gamut even after adding
         // the lowest channel to it.
         let rgb = WideRgb::new(-0.5, 0.4, 0.4, None, None).compress();
-        assert_eq!(rgb.values(), [0.0, 0.9, 0.9]);
+        assert_eq!(rgb.to_array(), [0.0, 0.9, 0.9]);
     }
 }

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -667,7 +667,7 @@ mod tests {
 
     #[test]
     fn d65_test() {
-        let [x, y, z] = D65.xyz(None).set_illuminance(100.0).values();
+        let [x, y, z] = D65.xyz(None).set_illuminance(100.0).to_array();
         assert_ulps_eq!(x, 95.04, epsilon = 5E-3);
         assert_ulps_eq!(y, 100.0, epsilon = 5E-3);
         assert_ulps_eq!(z, 108.86, epsilon = 5E-3);

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -211,7 +211,7 @@ impl Spectrum {
     /// Returns the spectral data values, as an array of floats.
     ///
     /// The array contains the 401 data points from 380 to 780 nanometer.
-    pub fn values(&self) -> &[f64; NS] {
+    pub fn as_array(&self) -> &[f64; NS] {
         &self.0.data.0[0]
     }
 }
@@ -244,7 +244,7 @@ impl Default for Spectrum {
 
 impl AsRef<[f64; 401]> for Spectrum {
     fn as_ref(&self) -> &[f64; 401] {
-        self.values()
+        self.as_array()
     }
 }
 

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -160,7 +160,7 @@ impl XYZ {
     /// assert_eq!(xyz.x(), 95.1);
     /// ```
     pub fn x(&self) -> f64 {
-        self.values()[0]
+        self.to_array()[0]
     }
 
     /// Returns the luminous value Y of the tristimulus values.
@@ -176,7 +176,7 @@ impl XYZ {
     /// assert_eq!(xyz.y(), 95.0);
     /// ```
     pub fn y(&self) -> f64 {
-        self.values()[1]
+        self.to_array()[1]
     }
 
     /// Returns the Z value.
@@ -187,7 +187,7 @@ impl XYZ {
     /// assert_eq!(xyz.z(), 27.0);
     /// ```
     pub fn z(&self) -> f64 {
-        self.values()[2]
+        self.to_array()[2]
     }
 
     /// Returns the observer used for this `XYZ` value.
@@ -201,13 +201,13 @@ impl XYZ {
     /// use approx::assert_ulps_eq;
     ///
     /// let d65_xyz = Cie1931.xyz(&CieIlluminant::D65, None).set_illuminance(100.0);
-    /// let [x, y, z] = d65_xyz.values();
+    /// let [x, y, z] = d65_xyz.to_array();
     /// // Calculated Spreadsheet Values from CIE Datasets, over a range from 380 to 780nm
     /// assert_ulps_eq!(x, 95.042_267, epsilon = 1E-6);
     /// assert_ulps_eq!(y, 100.0);
     /// assert_ulps_eq!(z, 108.861_036, epsilon = 1E-6);
     /// ```
-    pub fn values(&self) -> [f64; 3] {
+    pub fn to_array(&self) -> [f64; 3] {
         *self.xyz.as_ref()
     }
 
@@ -245,7 +245,7 @@ impl XYZ {
     /// assert_ulps_eq!(chromaticity.to_array().as_ref(), [0.312_738, 0.329_052].as_slice(), epsilon = 1E-6);
     /// ```
     pub fn chromaticity(&self) -> Chromaticity {
-        let [x, y, z] = self.values();
+        let [x, y, z] = self.to_array();
         let s = x + y + z;
         Chromaticity::new(x / s, y / s)
     }
@@ -335,7 +335,7 @@ impl XYZ {
 impl From<XYZ> for [f64; 3] {
     /// Converts the tristimulus values to an array on the format [X, Y, Z]
     fn from(xyz: XYZ) -> Self {
-        xyz.values()
+        xyz.to_array()
     }
 }
 
@@ -447,7 +447,7 @@ mod xyz_test {
             [95.04, 100.0, 108.867].as_slice(),
             epsilon = 1E-2
         );
-        let xyz = d65.values();
+        let xyz = d65.to_array();
         assert_ulps_eq!(
             xyz.as_ref(),
             [95.04, 100.0, 108.867].as_slice(),

--- a/src/xyz/rel_xyz.rs
+++ b/src/xyz/rel_xyz.rs
@@ -114,7 +114,7 @@ impl RelXYZ {
     /// Returns the XYZ tristimulus values of the color and the reference white point as a 2D array.
     ///
     /// The first row contains the XYZ values of the color, and the second row contains the XYZ values of the reference white point.        
-    pub fn values(&self) -> [[f64; 3]; 2] {
+    pub fn to_arrays(&self) -> [[f64; 3]; 2] {
         [self.xyz.into(), self.white_point.xyz.into()]
     }
 
@@ -257,10 +257,10 @@ mod tests {
 
         let sl = Cie1931.monochromes(CieIlluminant::D65);
         for (w, rxyz) in sl {
-            print!("{}, {:.4?}", w, rxyz.values()[0]);
+            print!("{}, {:.4?}", w, rxyz.to_arrays()[0]);
             let lab = CieLab::from_rxyz(rxyz);
             let xyz_back = lab.rxyz();
-            println!("{:.4?}", xyz_back.values()[0]);
+            println!("{:.4?}", xyz_back.to_arrays()[0]);
         }
     }
 

--- a/src/xyz/wasm.rs
+++ b/src/xyz/wasm.rs
@@ -28,7 +28,7 @@ impl XYZ {
     ///
     /// // Get and check the corresponding tristimulus values, with a luminous value
     /// // of 100.0
-    /// const [x, y, z] = xyz.values();
+    /// const [x, y, z] = xyz.to_array();
     /// assert.assertAlmostEquals(x, 95.047, 5E-3); // D65 wikipedia
     /// assert.assertAlmostEquals(y, 100.0);
     /// assert.assertAlmostEquals(z, 108.883, 5E-3);

--- a/xtask/src/gen_rgbspace.rs
+++ b/xtask/src/gen_rgbspace.rs
@@ -269,9 +269,9 @@ impl TemplateContext {
 
     pub fn stimuli_to_vecs(stimuli: &[Stimulus; 3]) -> [Vec<f64>; 3] {
         [
-            stimuli[0].as_ref().values().to_vec(),
-            stimuli[1].as_ref().values().to_vec(),
-            stimuli[2].as_ref().values().to_vec(),
+            stimuli[0].as_ref().as_array().to_vec(),
+            stimuli[1].as_ref().as_array().to_vec(),
+            stimuli[2].as_ref().as_array().to_vec(),
         ]
     }
     pub fn write(&self) -> Result<(), Box<dyn std::error::Error>> {

--- a/xtask/src/gen_rgbspace.rs
+++ b/xtask/src/gen_rgbspace.rs
@@ -245,7 +245,7 @@ impl TemplateContext {
         let mut out = Vec::new();
         for observer in Observer::iter() {
             let white_point = white.white_point(observer);
-            out.push(white_point.values());
+            out.push(white_point.to_array());
         }
         out
     }


### PR DESCRIPTION
The method name `values` was too generic and did not clearly convey that it produces a new owned array.  
This pull request renames these methods to `to_array`, which follows Rust naming conventions and makes the intent explicit: the method returns a fresh `[f64; 3]` rather than a reference.

**Note:**  
`to_array` was chosen over `as_array` because the method produces a new owned value.  
By convention, `as_*` is used for cheap, reference-based views, while `to_*` is used for owned conversions.