### PR TITLE
Bump actions/checkout from v4 to v5 in all workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
         rust: [stable, beta]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install and set correct Rust toolchain version
         run: rustup override set ${{ matrix.rust }}
@@ -53,7 +53,7 @@ jobs:
   build-wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install and set correct Rust toolchain version
         run: rustup override set stable
@@ -70,7 +70,7 @@ jobs:
   minimal-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install needed Rust toolchain versions
         run: |

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -10,7 +10,7 @@ jobs:
   check-formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install latest stable Rust
         run: rustup update stable

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
   clippy-linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install latest stable Rust
         run: rustup update stable

--- a/.github/workflows/rdme-check.yml
+++ b/.github/workflows/rdme-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # 1. Install (or pin) the Rust toolchain
       - uses: dtolnay/rust-toolchain@stable   # or @nightly / specific version


### PR DESCRIPTION
## Summary

- Updates `actions/checkout` from `v4` to `v5` in all four GitHub Actions workflow files (`build-and-test.yml`, `formatting.yml`, `linting.yml`, `rdme-check.yml`)

## Test plan

- [ ] Verify all CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)