### PR TITLE
Code review fixes: correctness, docs, and style

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ dual licensed as above, without any additional terms or conditions.
 [`Observer`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html
 [`Observer::Cie1931`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie1931
 [`Observer::Cie1964`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie1964
-[`Observer::Cie2015`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Ci2015e
+[`Observer::Cie2015`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie2015
 [`Observer::Cie2015_10`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie2015_10
 [`XYZ`]: https://docs.rs/colorimetry/latest/colorimetry/xyz/struct.XYZ.html
 [`Rgb`]: https://docs.rs/colorimetry/latest/colorimetry/rgb/struct.RGB.html

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,7 +59,7 @@ pub enum Error {
     InvalidHue(f64),
     #[error("Invalid Hue Bin (0..72): {0}")]
     InvalidHueBin(u8),
-    #[error("Index Out Of Range: {0} should be betwen{1} and {2}")]
+    #[error("Index Out Of Range: {0} should be between {1} and {2}")]
     IndexOutOfRange(usize, usize, usize),
 }
 

--- a/src/illuminant/cri.rs
+++ b/src/illuminant/cri.rs
@@ -94,12 +94,12 @@ impl TryFrom<&Illuminant> for CRI {
     type Error = Error;
 
     fn try_from(illuminant: &Illuminant) -> Result<Self, Self::Error> {
-        let illuminant = &illuminant.clone().set_illuminance(Cie1931, 100.0);
+        let illuminant = illuminant.clone().set_illuminance(Cie1931, 100.0);
         // Calculate Device Under Test (dut) XYZ illuminant and sample values
         let xyz_dut = Cie1931.xyz_from_spectrum(illuminant.as_ref());
         let xyz_dut_samples: [XYZ; N_TCS] = TCS
             .each_ref()
-            .map(|colorant| Cie1931.xyz(illuminant, Some(colorant)));
+            .map(|colorant| Cie1931.xyz(&illuminant, Some(colorant)));
 
         // Determine reference color temperarture value
         let cct_dut = xyz_dut.cct()?.t();

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -286,6 +286,11 @@ fn lab(xyz: Vector3<f64>, xyzn: Vector3<f64>) -> Vector3<f64> {
     let &[x, y, z] = xyz.as_ref();
     let &[xn, yn, zn] = xyzn.as_ref();
 
+    assert!(
+        xn > 0.0 && yn > 0.0 && zn > 0.0,
+        "White point XYZ components must all be positive (got Xn={xn}, Yn={yn}, Zn={zn})"
+    );
+
     let lab_f = |t: f64| {
         if t > DELTA {
             t.cbrt()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ dual licensed as above, without any additional terms or conditions.
 [`Observer`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html
 [`Observer::Cie1931`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie1931
 [`Observer::Cie1964`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie1964
-[`Observer::Cie2015`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Ci2015e
+[`Observer::Cie2015`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie2015
 [`Observer::Cie2015_10`]: https://docs.rs/colorimetry/latest/colorimetry/observer/enum.Observer.html#variant.Cie2015_10
 [`XYZ`]: https://docs.rs/colorimetry/latest/colorimetry/xyz/struct.XYZ.html
 [`Rgb`]: https://docs.rs/colorimetry/latest/colorimetry/rgb/struct.RGB.html

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -298,7 +298,8 @@ impl Observer {
     ///
     /// Values are not normalized by default, unless an illuminance value is provided.
     ///
-    /// TODO: buffer values
+    /// Results are not cached. For the common cases of D65 and D50, use the dedicated
+    /// [`Observer::xyz_d65`] and [`Observer::xyz_d50`] methods, which cache their results.
     pub fn xyz_cie_table(&self, std_illuminant: &CieIlluminant, illuminance: Option<f64>) -> XYZ {
         let xyz = self.xyz_from_spectrum(std_illuminant.illuminant().as_ref());
         if let Some(l) = illuminance {

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -404,6 +404,12 @@ impl Index<usize> for Spectrum {
     type Output = f64;
 
     fn index(&self, i: usize) -> &Self::Output {
+        assert!(
+            SPECTRUM_WAVELENGTH_RANGE.contains(&i),
+            "Wavelength index {i} nm is out of range ({}..={})",
+            SPECTRUM_WAVELENGTH_RANGE.start(),
+            SPECTRUM_WAVELENGTH_RANGE.end()
+        );
         &self.0[(i - SPECTRUM_WAVELENGTH_RANGE.start(), 0)]
     }
 }
@@ -416,13 +422,19 @@ impl Index<usize> for Spectrum {
 /// Panic if the index is less than 380 or greater than 780.
 impl IndexMut<usize> for Spectrum {
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
+        assert!(
+            SPECTRUM_WAVELENGTH_RANGE.contains(&i),
+            "Wavelength index {i} nm is out of range ({}..={})",
+            SPECTRUM_WAVELENGTH_RANGE.start(),
+            SPECTRUM_WAVELENGTH_RANGE.end()
+        );
         &mut self.0[(i - SPECTRUM_WAVELENGTH_RANGE.start(), 0)]
     }
 }
 
 /// Linear interpolation over a dataset over an equidistant wavelength domain
 fn linterp(mut wl: [f64; 2], data: &[f64]) -> Result<[f64; NS], Error> {
-    wl.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    wl.sort_by(f64::total_cmp);
     let [wl, wh] = wavelengths(wl);
     let dlm1 = data.len() - 1; // data length min one
 
@@ -513,7 +525,7 @@ fn sprinterp(mut wl: [f64; 2], data: &[f64]) -> Result<[f64; NS], Error> {
         }
     };
 
-    wl.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    wl.sort_by(f64::total_cmp);
     let [wl, wh] = wavelengths(wl);
 
     let mut spd = [0f64; NS];

--- a/src/stimulus.rs
+++ b/src/stimulus.rs
@@ -66,7 +66,7 @@ impl Stimulus {
     }
 
     /// A spectral composition of a display pixel, set to three sRGB color values.  The spectrum is
-    /// a linear combination of the spectral primaries, which are Gaudssian filtered components in
+    /// a linear combination of the spectral primaries, which are Gaussian filtered components in
     /// this library.
     pub fn from_srgb(r_u8: u8, g_u8: u8, b_u8: u8) -> Self {
         let rgb = Rgb::from_u8(
@@ -80,7 +80,7 @@ impl Stimulus {
     }
 
     /// A spectral composition of a display pixel, set to three sRGB color values.  The spectrum is
-    /// a linear combination of the spectral primaries, which are Gaudssian filtered components in
+    /// a linear combination of the spectral primaries, which are Gaussian filtered components in
     /// this library.
     pub fn from_rgb(rgb: Rgb) -> Self {
         rgb.into()

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -236,6 +236,11 @@ impl XYZ {
     }
 
     /// Returns the chromaticity coordinates of this `XYZ` value.
+    ///
+    /// Returns `NaN` chromaticity coordinates if X + Y + Z = 0 (absolute black), for which
+    /// chromaticity is mathematically undefined. Use [`XYZ::try_chromaticity`] if you need
+    /// explicit handling of the black case.
+    ///
     /// ```
     /// use approx::assert_ulps_eq;
     /// use colorimetry::{illuminant::CieIlluminant, observer::Observer::Cie1931, xyz::XYZ};
@@ -248,6 +253,18 @@ impl XYZ {
         let [x, y, z] = self.to_array();
         let s = x + y + z;
         Chromaticity::new(x / s, y / s)
+    }
+
+    /// Returns the chromaticity coordinates of this `XYZ` value, or `None` for absolute black
+    /// (X + Y + Z = 0), for which chromaticity is undefined.
+    pub fn try_chromaticity(&self) -> Option<Chromaticity> {
+        let [x, y, z] = self.to_array();
+        let s = x + y + z;
+        if s == 0.0 {
+            None
+        } else {
+            Some(Chromaticity::new(x / s, y / s))
+        }
     }
 
     /// CIE 1960 UCS Color Space uv coordinates *Deprecated* by the CIE, but
@@ -387,11 +404,15 @@ impl std::ops::Add<XYZ> for XYZ {
 
     /// Add tristimulus values using the "+" operator.
     ///
-    /// Panics if not the same oberver is used.
+    /// # Panics
+    ///
+    /// Panics if the two XYZ values use different observers.
     fn add(mut self, rhs: XYZ) -> Self::Output {
         assert!(
             self.observer == rhs.observer,
-            "Can not add two XYZ values for different observers"
+            "Cannot add XYZ values with different observers ({:?} vs {:?})",
+            self.observer,
+            rhs.observer
         );
         self.xyz += rhs.xyz;
         self
@@ -403,11 +424,15 @@ impl std::ops::Sub<XYZ> for XYZ {
 
     /// Subtract tristimulus values using the "-" operator.
     ///
-    /// Panics if not the same observer is used.
+    /// # Panics
+    ///
+    /// Panics if the two XYZ values use different observers.
     fn sub(mut self, rhs: XYZ) -> Self::Output {
         assert!(
             self.observer == rhs.observer,
-            "Can not subtract two XYZ values for different observers"
+            "Cannot subtract XYZ values with different observers ({:?} vs {:?})",
+            self.observer,
+            rhs.observer
         );
         self.xyz -= rhs.xyz;
         self


### PR DESCRIPTION
## Summary

Addresses 10 issues found in a code review of the library:

**Correctness**
- `spectrum.rs`: `Index`/`IndexMut` now emit a clear message (`"Wavelength index 300 nm is out of range (380..=780)"`) instead of a cryptic nalgebra panic or silent integer underflow on out-of-range wavelengths
- `spectrum.rs`: Replace `partial_cmp().unwrap()` with `f64::total_cmp` in two sort calls — NaN-safe and panic-free
- `lab.rs`: Assert white point components are all positive before dividing, preventing silent NaN/Inf propagation
- `xyz.rs`: `chromaticity()` documents its NaN-for-black behaviour; new `try_chromaticity() -> Option<Chromaticity>` for callers that need explicit handling

**API / docs**
- `xyz.rs`: Improve panic messages in `Add`/`Sub` operators to name which observers clashed; fix typo "oberver"
- `observer.rs`: Replace `TODO: buffer values` with a doc note explaining why `xyz_cie_table` is not cached and pointing to `xyz_d65`/`xyz_d50`
- `lib.rs`: Fix broken doc URL fragment (`Ci2015e` → `Cie2015`)

**Style / cleanup**
- `cri.rs`: Remove confusing reference-to-temporary pattern in `TryFrom<&Illuminant>`
- `error.rs`: Fix typo `"betwen"` → `"between"`
- `stimulus.rs`: Fix typo `"Gaudssian"` → `"Gaussian"` (two occurrences)

## Test plan

- [x] `cargo xtask check` — fmt, clippy, build, rdme all pass
- [x] `cargo xtask test` — 122 tests pass (all features and no-default-features)
- [x] `cargo xtask doc` — rustdoc with --deny warnings passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)